### PR TITLE
Improve compile times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Improved
+
+-   Rethink packages to improve compile speed
+    -   Improve build times by ~70%
+    -   Reduce binary size by ~75%
+    -   Move from async to sync to avoid runtime (reqwest to ureq)
+    -   Remove vendored libraries, rely on system libraries (e.g. native ssl)
+    -   Remove git2, and move to git command parsing
+    -   Remove color-eyre, add manual error printing
+
 ## [0.1.2] - 2023-03-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,31 +233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "cxx"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,12 +295,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "errno"
@@ -428,8 +397,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -446,7 +413,6 @@ dependencies = [
  "colored",
  "dirs",
  "git2",
- "inquire",
  "open",
  "serde",
  "serde_json",
@@ -517,22 +483,6 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
-name = "inquire"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a94f0659efe59329832ba0452d3ec753145fc1fb12a8e1d60de4ccf99f5364"
-dependencies = [
- "bitflags",
- "crossterm",
- "dyn-clone",
- "lazy_static",
- "newline-converter",
- "thiserror",
- "unicode-segmentation",
- "unicode-width",
-]
 
 [[package]]
 name = "instant"
@@ -609,24 +559,8 @@ checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -655,16 +589,6 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -700,18 +624,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,15 +639,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "newline-converter"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -855,29 +758,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,21 +868,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,18 +888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,26 +903,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -1135,46 +972,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1378,22 +1179,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
@@ -1406,12 +1195,9 @@ dependencies = [
  "log",
  "native-tls",
  "once_cell",
- "rustls",
  "serde",
  "serde_json",
  "url",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1514,35 +1300,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
-
-[[package]]
-name = "web-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,16 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,15 +318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,21 +326,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -485,22 +451,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -512,7 +469,7 @@ dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -600,15 +557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,24 +569,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -692,51 +622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21ecf2487e799604735754d2c5896106785987b441b5aee58f242e4d4963179a"
 dependencies = [
  "pathdiff",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -844,28 +729,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.7.1"
+name = "ring"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
- "regex-syntax",
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustc-demangle"
@@ -884,7 +760,19 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -894,41 +782,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
-name = "schannel"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
-dependencies = [
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
-name = "security-framework"
-version = "2.8.2"
+name = "sct"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -978,6 +844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,19 +864,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1142,16 +1001,12 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
@@ -1185,6 +1040,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "ureq"
 version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,11 +1054,13 @@ dependencies = [
  "base64 0.13.1",
  "flate2",
  "log",
- "native-tls",
  "once_cell",
+ "rustls",
  "serde",
  "serde_json",
  "url",
+ "webpki",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1302,6 +1165,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,21 +1223,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -75,12 +81,6 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
-
-[[package]]
-name = "bytes"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
@@ -224,6 +224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,15 +328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,10 +368,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "flate2"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foreign-types"
@@ -395,54 +399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
-
-[[package]]
-name = "futures-io"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
-
-[[package]]
-name = "futures-task"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
-
-[[package]]
-name = "futures-util"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -482,6 +438,7 @@ name = "gr-bin"
 version = "0.1.2"
 dependencies = [
  "atty",
+ "base64 0.21.0",
  "chrono",
  "clap",
  "clap_complete",
@@ -491,39 +448,14 @@ dependencies = [
  "git2",
  "inquire",
  "open",
- "reqwest",
  "serde",
  "serde_json",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "ureq",
  "urlencoding",
 ]
-
-[[package]]
-name = "h2"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -542,89 +474,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
-name = "http"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "hyper"
-version = "0.14.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -667,16 +519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
-name = "indexmap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "inquire"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,12 +552,6 @@ dependencies = [
  "libc",
  "windows-sys 0.45.0",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
@@ -855,12 +691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,16 +765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
 ]
 
 [[package]]
@@ -1076,12 +896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,40 +988,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "reqwest"
-version = "0.11.14"
+name = "ring"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
+ "cc",
+ "libc",
  "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
+ "spin",
+ "untrusted",
  "web-sys",
- "winreg",
+ "winapi",
 ]
 
 [[package]]
@@ -1228,6 +1020,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1256,6 +1060,16 @@ name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -1312,18 +1126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,29 +1165,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "socket2"
-version = "0.4.9"
+name = "spin"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1483,53 +1272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
-dependencies = [
- "autocfg",
- "bytes",
- "libc",
- "memchr",
- "mio",
- "num_cpus",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,12 +1357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,6 +1388,31 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
+dependencies = [
+ "base64 0.13.1",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
 
 [[package]]
 name = "url"
@@ -1687,16 +1448,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "want"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-dependencies = [
- "log",
- "try-lock",
-]
 
 [[package]]
 name = "wasi"
@@ -1736,18 +1487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,6 +1523,25 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]
@@ -1897,12 +1655,3 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,19 +669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
-dependencies = [
- "http",
- "hyper",
- "rustls",
- "tokio",
- "tokio-rustls",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,15 +1059,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "111.25.1+1.1.1t"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef9a9cc6ea7d9d5e7c4a913dc4b48d0e359eddf01af1dfec96ba7064b4aba10"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,7 +1067,6 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1266,7 +1243,6 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1276,36 +1252,17 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -1326,27 +1283,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
-dependencies = [
- "base64",
 ]
 
 [[package]]
@@ -1375,16 +1311,6 @@ name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -1515,12 +1441,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1654,17 +1574,6 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls",
- "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -1812,12 +1721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,25 +1851,6 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,12 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bumpalo"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,22 +81,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-integer",
- "num-traits",
- "serde",
- "time",
- "wasm-bindgen",
- "winapi",
-]
 
 [[package]]
 name = "clap"
@@ -157,16 +126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
 ]
 
 [[package]]
@@ -230,50 +189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -378,7 +293,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -406,7 +321,6 @@ version = "0.1.2"
 dependencies = [
  "atty",
  "base64 0.21.0",
- "chrono",
  "clap",
  "clap_complete",
  "color-eyre",
@@ -417,6 +331,7 @@ dependencies = [
  "open",
  "serde",
  "serde_json",
+ "time",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
@@ -444,30 +359,6 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
 
 [[package]]
 name = "idna"
@@ -532,15 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,15 +456,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -641,25 +514,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -871,12 +725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "security-framework"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,13 +864,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -1143,12 +1007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "ureq"
 version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,69 +1059,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,12 +32,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,7 +241,7 @@ name = "gr-bin"
 version = "0.1.2"
 dependencies = [
  "atty",
- "base64 0.21.0",
+ "base64",
  "clap",
  "clap_complete",
  "colored",
@@ -859,7 +853,7 @@ version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "flate2",
  "log",
  "native-tls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,21 +24,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -126,33 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "color-eyre"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
 ]
 
 [[package]]
@@ -297,12 +246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
-
-[[package]]
 name = "git2"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,9 +266,9 @@ dependencies = [
  "base64 0.21.0",
  "clap",
  "clap_complete",
- "color-eyre",
  "colored",
  "dirs",
+ "eyre",
  "git2",
  "native-tls",
  "open",
@@ -474,12 +417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,15 +451,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "object"
-version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -596,12 +524,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "pathdiff"
@@ -688,12 +610,6 @@ dependencies = [
  "redox_syscall",
  "thiserror",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +328,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +345,21 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -379,6 +413,7 @@ dependencies = [
  "colored",
  "dirs",
  "git2",
+ "native-tls",
  "open",
  "serde",
  "serde_json",
@@ -451,13 +486,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -469,7 +513,7 @@ dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -572,6 +616,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +684,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21ecf2487e799604735754d2c5896106785987b441b5aee58f242e4d4963179a"
 dependencies = [
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -729,21 +836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,19 +852,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -782,19 +862,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
-name = "sct"
-version = "0.7.0"
+name = "security-framework"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "ring",
- "untrusted",
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -844,12 +946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +960,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1040,12 +1149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "ureq"
 version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,13 +1157,11 @@ dependencies = [
  "base64 0.13.1",
  "flate2",
  "log",
+ "native-tls",
  "once_cell",
- "rustls",
  "serde",
  "serde_json",
  "url",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1165,35 +1266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
-name = "web-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1295,21 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,16 +444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,12 +508,6 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pathdiff"
@@ -704,12 +688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,17 +842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,14 +857,11 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "nu-ansi-term",
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,6 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -246,19 +243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "gr-bin"
 version = "0.1.2"
 dependencies = [
@@ -269,7 +253,6 @@ dependencies = [
  "colored",
  "dirs",
  "eyre",
- "git2",
  "native-tls",
  "open",
  "serde",
@@ -357,15 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,30 +350,6 @@ name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
-
-[[package]]
-name = "libgit2-sys"
-version = "0.14.2+1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,17 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,28 +398,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -440,32 +413,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -485,11 +436,8 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -533,7 +481,6 @@ dependencies = [
 name = "gr-bin"
 version = "0.1.2"
 dependencies = [
- "async-trait",
  "atty",
  "chrono",
  "clap",
@@ -541,14 +488,12 @@ dependencies = [
  "color-eyre",
  "colored",
  "dirs",
- "futures",
  "git2",
  "inquire",
  "open",
  "reqwest",
  "serde",
  "serde_json",
- "tokio",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
@@ -1551,19 +1496,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +468,12 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pathdiff"
@@ -807,6 +823,7 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
+ "nu-ansi-term",
  "serde",
  "serde_json",
  "sharded-slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/daniel7grant/gr"
 [dependencies]
 atty = "0.2.14"
 base64 = "0.21.0"
-chrono = { version = "0.4.23", features = ["serde"] }
 clap = { version = "4.1.1", features = ["derive"] }
 clap_complete = "4.1.0"
 color-eyre = "0.6.2"
@@ -21,6 +20,7 @@ native-tls = "0.2.11"
 open = "3.2.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
+time = { version = "0.3.20", features = ["serde-well-known"] }
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ color-eyre = "0.6.2"
 colored = "2.0.0"
 dirs = "4.0.0"
 futures = "0.3.25"
-git2 = { version = "0.16.0", features = ["vendored-libgit2", "vendored-openssl"] }
+git2 = "0.16.0"
 inquire = "0.5.3"
 open = "3.2.0"
-reqwest = { version = "0.11.13", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11.13", features = ["json", "native-tls"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ documentation = "https://github.com/daniel7grant/gr"
 repository = "https://github.com/daniel7grant/gr"
 
 [dependencies]
-async-trait = "0.1.61"
 atty = "0.2.14"
 chrono = { version = "0.4.23", features = ["serde"] }
 clap = { version = "4.1.1", features = ["derive"] }
@@ -16,14 +15,12 @@ clap_complete = "4.1.0"
 color-eyre = "0.6.2"
 colored = "2.0.0"
 dirs = "4.0.0"
-futures = "0.3.25"
 git2 = "0.16.0"
 inquire = "0.5.3"
 open = "3.2.0"
-reqwest = { version = "0.11.13", features = ["json", "native-tls"] }
+reqwest = { version = "0.11.13", features = ["blocking", "json", "native-tls"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ atty = "0.2.14"
 base64 = "0.21.0"
 clap = { version = "4.1.1", features = ["derive"] }
 clap_complete = "4.1.0"
-color-eyre = "0.6.2"
 colored = "2.0.0"
 dirs = "4.0.0"
+eyre = "0.6.8"
 git2 = { version = "0.16.0", default-features = false }
 native-tls = "0.2.11"
 open = "3.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ color-eyre = "0.6.2"
 colored = "2.0.0"
 dirs = "4.0.0"
 git2 = { version = "0.16.0", default-features = false }
+native-tls = "0.2.11"
 open = "3.2.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["json"] }
-ureq = { version = "2.6.2", features = ["json"] }
+ureq = { version = "2.6.2", default-features = false, features = ["gzip", "json", "native-tls"] }
 urlencoding = "2.1.2"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.91"
 time = { version = "0.3.20", features = ["serde-well-known"] }
 tracing = "0.1.37"
 tracing-error = "0.2.0"
-tracing-subscriber = { version = "0.3.16", default-features = false, features = ["json"] }
+tracing-subscriber = { version = "0.3.16", default-features = false, features = ["ansi", "json"] }
 ureq = { version = "2.6.2", default-features = false, features = ["gzip", "json", "native-tls"] }
 urlencoding = "2.1.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,14 @@ clap_complete = "4.1.0"
 color-eyre = "0.6.2"
 colored = "2.0.0"
 dirs = "4.0.0"
-git2 = "0.16.0"
-inquire = "0.5.3"
+git2 = { version = "0.16.0", default-features = false }
 open = "3.2.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
-ureq = { version = "2.6.2", features = ["json", "native-tls"] }
+ureq = { version = "2.6.2", default-features = false, features = ["gzip", "json", "native-tls"] }
 urlencoding = "2.1.2"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0.91"
 time = { version = "0.3.20", features = ["serde-well-known"] }
 tracing = "0.1.37"
 tracing-error = "0.2.0"
-tracing-subscriber = { version = "0.3.16", features = ["json"] }
+tracing-subscriber = { version = "0.3.16", default-features = false, features = ["json"] }
 ureq = { version = "2.6.2", default-features = false, features = ["gzip", "json", "native-tls"] }
 urlencoding = "2.1.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ clap_complete = "4.1.0"
 colored = "2.0.0"
 dirs = "4.0.0"
 eyre = "0.6.8"
-git2 = { version = "0.16.0", default-features = false }
 native-tls = "0.2.11"
 open = "3.2.0"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/daniel7grant/gr"
 
 [dependencies]
 atty = "0.2.14"
-base64 = "0.21.0"
+base64 = "0.13.1"
 clap = { version = "4.1.1", features = ["derive"] }
 clap_complete = "4.1.0"
 colored = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
-ureq = { version = "2.6.2", default-features = false, features = ["gzip", "json", "native-tls"] }
+tracing-subscriber = { version = "0.3.16", features = ["json"] }
+ureq = { version = "2.6.2", features = ["json"] }
 urlencoding = "2.1.2"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/daniel7grant/gr"
 
 [dependencies]
 atty = "0.2.14"
+base64 = "0.21.0"
 chrono = { version = "0.4.23", features = ["serde"] }
 clap = { version = "4.1.1", features = ["derive"] }
 clap_complete = "4.1.0"
@@ -18,12 +19,12 @@ dirs = "4.0.0"
 git2 = "0.16.0"
 inquire = "0.5.3"
 open = "3.2.0"
-reqwest = { version = "0.11.13", features = ["blocking", "json", "native-tls"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
+ureq = { version = "2.6.2", features = ["json", "native-tls"] }
 urlencoding = "2.1.2"
 
 [[bin]]

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,5 +1,5 @@
-use color_eyre::{
-    eyre::{eyre, Context, ContextCompat},
+use eyre::{
+    eyre, Context, ContextCompat,
     Result,
 };
 use dirs::config_dir;

--- a/src/cmd/login/login.rs
+++ b/src/cmd/login/login.rs
@@ -11,11 +11,11 @@ use gr_bin::{
     vcs::common::{init_vcs, VersionControlSettings},
 };
 use inquire::Text;
-use tokio::time::{sleep, Duration};
+use std::{thread::sleep, time::Duration};
 use tracing::instrument;
 
 #[instrument(skip_all, fields(command = ?args.command))]
-pub async fn login(args: Cli, mut conf: Configuration) -> Result<()> {
+pub fn login(args: Cli, mut conf: Configuration) -> Result<()> {
     let Cli { command, dir, .. } = args;
     if let Commands::Login {
         hostname,
@@ -50,12 +50,12 @@ pub async fn login(args: Cli, mut conf: Configuration) -> Result<()> {
                 println!("The token needs account, workspace and project read, pull request read and write permissions.");
                 println!("You have to enter you username and the token separated with a colon (e.g. user:ATBB...).");
             }
-            sleep(Duration::from_millis(500)).await;
+            sleep(Duration::from_millis(500));
             let can_open = open::that(&url);
             if can_open.is_err() {
                 println!("Open this page: {}", &url);
             }
-            sleep(Duration::from_millis(500)).await;
+            sleep(Duration::from_millis(500));
 
             // Read the token from the user
             let mut token;

--- a/src/cmd/login/login.rs
+++ b/src/cmd/login/login.rs
@@ -10,8 +10,7 @@ use gr_bin::{
     git::{git::LocalRepository, url::parse_url},
     vcs::common::{init_vcs, VersionControlSettings},
 };
-use inquire::Text;
-use std::{thread::sleep, time::Duration};
+use std::{io, thread::sleep, time::Duration};
 use tracing::instrument;
 
 #[instrument(skip_all, fields(command = ?args.command))]
@@ -58,10 +57,12 @@ pub fn login(args: Cli, mut conf: Configuration) -> Result<()> {
             sleep(Duration::from_millis(500));
 
             // Read the token from the user
-            let mut token;
+            let mut token = String::new();
+            let stdin = io::stdin();
             loop {
-                token = Text::new("Paste the token here: ")
-                    .prompt()
+                print!("Paste the token here: ");
+                stdin
+                    .read_line(&mut token)
                     .wrap_err("Reading the token failed.")?;
                 match vcs.validate_token(&token) {
                     Ok(_) => break,

--- a/src/cmd/login/login.rs
+++ b/src/cmd/login/login.rs
@@ -2,8 +2,8 @@ use crate::cmd::{
     args::{Cli, Commands},
     config::{Configuration, RepositoryConfig},
 };
-use color_eyre::{
-    eyre::{eyre, Context},
+use eyre::{
+    eyre, Context,
     Result,
 };
 use gr_bin::{

--- a/src/cmd/login/login.rs
+++ b/src/cmd/login/login.rs
@@ -2,12 +2,9 @@ use crate::cmd::{
     args::{Cli, Commands},
     config::{Configuration, RepositoryConfig},
 };
-use eyre::{
-    eyre, Context,
-    Result,
-};
+use eyre::{eyre, Context, Result};
 use gr_bin::{
-    git::{git::LocalRepository, url::parse_url},
+    git::git::LocalRepository,
     vcs::common::{init_vcs, VersionControlSettings},
 };
 use std::{io, thread::sleep, time::Duration};
@@ -28,8 +25,7 @@ pub fn login(args: Cli, mut conf: Configuration) -> Result<()> {
             (hostname, repo_name.clone().unwrap_or_default())
         } else {
             let repo = LocalRepository::init(dir)?;
-            let (remote_url, _) = repo.get_remote_branch(None)?;
-            let (hostname, repo) = parse_url(&remote_url)?;
+            let (hostname, repo, _) = repo.get_parsed_remote(None)?;
 
             (hostname, repo)
         };

--- a/src/cmd/pr/approve.rs
+++ b/src/cmd/pr/approve.rs
@@ -14,7 +14,7 @@ use gr_bin::{
 use tracing::instrument;
 
 #[instrument(skip_all, fields(command = ?args.command))]
-pub async fn approve(args: Cli, conf: Configuration) -> Result<()> {
+pub fn approve(args: Cli, conf: Configuration) -> Result<()> {
     let Cli {
         command,
         branch,
@@ -44,8 +44,8 @@ pub async fn approve(args: Cli, conf: Configuration) -> Result<()> {
         };
 
         let vcs = init_vcs(hostname, repo, settings);
-        let pr = vcs.get_pr_by_branch(&remote_branch).await?;
-        vcs.approve_pr(pr.id).await?;
+        let pr = vcs.get_pr_by_branch(&remote_branch)?;
+        vcs.approve_pr(pr.id)?;
         pr.print(false, output.into());
         Ok(())
     } else {

--- a/src/cmd/pr/approve.rs
+++ b/src/cmd/pr/approve.rs
@@ -2,10 +2,7 @@ use crate::cmd::{
     args::{Cli, Commands, PrCommands},
     config::Configuration,
 };
-use color_eyre::{
-    eyre::{eyre, ContextCompat},
-    Result,
-};
+use eyre::{eyre, ContextCompat, Result};
 use gr_bin::vcs::common::init_vcs;
 use gr_bin::{
     git::{git::LocalRepository, url::parse_url},

--- a/src/cmd/pr/close.rs
+++ b/src/cmd/pr/close.rs
@@ -14,7 +14,7 @@ use gr_bin::{
 use tracing::instrument;
 
 #[instrument(skip_all, fields(command = ?args.command))]
-pub async fn close(args: Cli, conf: Configuration) -> Result<()> {
+pub fn close(args: Cli, conf: Configuration) -> Result<()> {
     let Cli {
         command,
         branch,
@@ -44,8 +44,8 @@ pub async fn close(args: Cli, conf: Configuration) -> Result<()> {
         };
 
         let vcs = init_vcs(hostname, repo, settings);
-        let pr = vcs.get_pr_by_branch(&remote_branch).await?;
-        let pr = vcs.close_pr(pr.id).await?;
+        let pr = vcs.get_pr_by_branch(&remote_branch)?;
+        let pr = vcs.close_pr(pr.id)?;
         pr.print(false, output.into());
         Ok(())
     } else {

--- a/src/cmd/pr/close.rs
+++ b/src/cmd/pr/close.rs
@@ -2,8 +2,8 @@ use crate::cmd::{
     args::{Cli, Commands, PrCommands},
     config::Configuration,
 };
-use color_eyre::{
-    eyre::{eyre, ContextCompat},
+use eyre::{
+    eyre, ContextCompat,
     Result,
 };
 use gr_bin::vcs::common::init_vcs;

--- a/src/cmd/pr/create.rs
+++ b/src/cmd/pr/create.rs
@@ -17,7 +17,7 @@ use gr_bin::{
 use tracing::{debug, info, instrument, trace};
 
 #[instrument(skip_all, fields(command = ?args.command))]
-pub async fn create(args: Cli, mut conf: Configuration) -> Result<()> {
+pub fn create(args: Cli, mut conf: Configuration) -> Result<()> {
     let Cli {
         command,
         branch,
@@ -115,14 +115,14 @@ pub async fn create(args: Cli, mut conf: Configuration) -> Result<()> {
                 close_source_branch: delete,
                 reviewers: reviewers.unwrap_or_default(),
             })
-            .await?;
+            ?;
 
         pr.print(open, output.into());
 
         // Merge the PR instantly if merge is passed
         if merge {
             info!("Merging pull request {} instantly.", pr.id);
-            pr = vcs.merge_pr(pr.id, false).await?;
+            pr = vcs.merge_pr(pr.id, false)?;
 
             let target_branch = pr.target.clone();
 

--- a/src/cmd/pr/create.rs
+++ b/src/cmd/pr/create.rs
@@ -4,8 +4,8 @@ use crate::cmd::{
     args::{Cli, Commands, OutputType, PrCommands},
     config::{Configuration, RepositoryConfig},
 };
-use color_eyre::{
-    eyre::{eyre, ContextCompat},
+use eyre::{
+    eyre, ContextCompat,
     Result,
 };
 use colored::Colorize;

--- a/src/cmd/pr/get.rs
+++ b/src/cmd/pr/get.rs
@@ -14,7 +14,7 @@ use gr_bin::{
 use tracing::instrument;
 
 #[instrument(skip_all, fields(command = ?args.command))]
-pub async fn get(args: Cli, conf: Configuration) -> Result<()> {
+pub fn get(args: Cli, conf: Configuration) -> Result<()> {
     let Cli {
         command,
         branch,
@@ -45,7 +45,7 @@ pub async fn get(args: Cli, conf: Configuration) -> Result<()> {
 
         let vcs = init_vcs(hostname, repo, settings);
 
-        let pr = vcs.get_pr_by_branch(&remote_branch).await?;
+        let pr = vcs.get_pr_by_branch(&remote_branch)?;
         pr.print(open, output.into());
         Ok(())
     } else {

--- a/src/cmd/pr/get.rs
+++ b/src/cmd/pr/get.rs
@@ -2,8 +2,8 @@ use crate::cmd::{
     args::{Cli, Commands, PrCommands},
     config::Configuration,
 };
-use color_eyre::{
-    eyre::{eyre, ContextCompat},
+use eyre::{
+    eyre, ContextCompat,
     Result,
 };
 use gr_bin::vcs::common::init_vcs;

--- a/src/cmd/pr/list.rs
+++ b/src/cmd/pr/list.rs
@@ -19,7 +19,7 @@ use gr_bin::{
 use tracing::instrument;
 
 #[instrument(skip_all, fields(command = ?args.command))]
-pub async fn list(args: Cli, conf: Configuration) -> Result<()> {
+pub fn list(args: Cli, conf: Configuration) -> Result<()> {
     let Cli {
         command,
         dir,
@@ -67,7 +67,7 @@ pub async fn list(args: Cli, conf: Configuration) -> Result<()> {
                     Some(UserFilter::All) | None => PullRequestUserFilter::All,
                 },
             })
-            .await?;
+            ?;
 
         for pr in prs {
             match output {

--- a/src/cmd/pr/list.rs
+++ b/src/cmd/pr/list.rs
@@ -2,8 +2,8 @@ use crate::cmd::{
     args::{Cli, Commands, OutputType, PrCommands, StateFilter, UserFilter},
     config::Configuration,
 };
-use color_eyre::{
-    eyre::{eyre, ContextCompat},
+use eyre::{
+    eyre, ContextCompat,
     Result,
 };
 use gr_bin::{

--- a/src/cmd/pr/merge.rs
+++ b/src/cmd/pr/merge.rs
@@ -2,8 +2,8 @@ use crate::cmd::{
     args::{Cli, Commands, OutputType, PrCommands},
     config::Configuration,
 };
-use color_eyre::{
-    eyre::{eyre, ContextCompat},
+use eyre::{
+    eyre, ContextCompat,
     Result,
 };
 use colored::Colorize;

--- a/src/cmd/pr/merge.rs
+++ b/src/cmd/pr/merge.rs
@@ -2,16 +2,10 @@ use crate::cmd::{
     args::{Cli, Commands, OutputType, PrCommands},
     config::Configuration,
 };
-use eyre::{
-    eyre, ContextCompat,
-    Result,
-};
 use colored::Colorize;
+use eyre::{eyre, ContextCompat, Result};
 use gr_bin::vcs::common::init_vcs;
-use gr_bin::{
-    git::{git::LocalRepository, url::parse_url},
-    vcs::common::VersionControlSettings,
-};
+use gr_bin::{git::git::LocalRepository, vcs::common::VersionControlSettings};
 use tracing::{info, instrument};
 
 #[instrument(skip_all, fields(command = ?args.command))]
@@ -26,8 +20,7 @@ pub fn merge(args: Cli, conf: Configuration) -> Result<()> {
     } = args;
     if let Commands::Pr(PrCommands::Merge { delete }) = command {
         let repository = LocalRepository::init(dir)?;
-        let (remote_url, remote_branch) = repository.get_remote_branch(branch)?;
-        let (hostname, repo) = parse_url(&remote_url)?;
+        let (hostname, repo, branch) = repository.get_parsed_remote(branch)?;
 
         // Find settings or use the auth command
         let settings = conf.find_settings(&hostname, &repo);
@@ -46,14 +39,17 @@ pub fn merge(args: Cli, conf: Configuration) -> Result<()> {
 
         // Merge the PR
         let vcs = init_vcs(hostname, repo, settings);
-        let pr = vcs.get_pr_by_branch(&remote_branch)?;
+        let pr = vcs.get_pr_by_branch(&branch)?;
         let pr = vcs.merge_pr(pr.id, delete)?;
 
         pr.print(false, output.into());
 
         // Checkout to the target branch
         let target_branch = pr.target;
-        let message = format!("Checking out to {} and pulling after merge.", target_branch.blue());
+        let message = format!(
+            "Checking out to {} and pulling after merge.",
+            target_branch.blue()
+        );
         match output {
             OutputType::Json => info!("{}", message),
             _ => println!("{}", message),

--- a/src/cmd/pr/merge.rs
+++ b/src/cmd/pr/merge.rs
@@ -15,7 +15,7 @@ use gr_bin::{
 use tracing::{info, instrument};
 
 #[instrument(skip_all, fields(command = ?args.command))]
-pub async fn merge(args: Cli, conf: Configuration) -> Result<()> {
+pub fn merge(args: Cli, conf: Configuration) -> Result<()> {
     let Cli {
         command,
         branch,
@@ -46,8 +46,8 @@ pub async fn merge(args: Cli, conf: Configuration) -> Result<()> {
 
         // Merge the PR
         let vcs = init_vcs(hostname, repo, settings);
-        let pr = vcs.get_pr_by_branch(&remote_branch).await?;
-        let pr = vcs.merge_pr(pr.id, delete).await?;
+        let pr = vcs.get_pr_by_branch(&remote_branch)?;
+        let pr = vcs.merge_pr(pr.id, delete)?;
 
         pr.print(false, output.into());
 

--- a/src/formatters/formatter.rs
+++ b/src/formatters/formatter.rs
@@ -1,6 +1,5 @@
 use crate::vcs::common::{PullRequest, PullRequestState};
 use colored::Colorize;
-
 use super::utils::to_fixed_length;
 
 pub enum FormatterType {
@@ -47,9 +46,9 @@ impl Formatter for PullRequest {
             "opened by".dimmed(),
             self.author.username,
             "on".dimmed(),
-            self.created_at.format("%Y-%m-%d"),
+            self.created_at.date(),
             "updated on".dimmed(),
-            self.updated_at.format("%Y-%m-%d")
+            self.updated_at.date(),
         );
         let branch_line = format!("{} -> {}", self.source.blue(), self.target.blue());
         let description = if self.description.len() > 0 {

--- a/src/git/git.rs
+++ b/src/git/git.rs
@@ -1,7 +1,6 @@
+use crate::git::url::parse_url;
 use eyre::{eyre, Context, ContextCompat, Result};
-use git2::{BranchType, ObjectType, Oid, Repository, RepositoryOpenFlags, Sort};
 use std::{
-    collections::HashSet,
     env,
     path::PathBuf,
     process::{Command, Stdio},
@@ -9,7 +8,6 @@ use std::{
 use tracing::{debug, info, instrument};
 
 pub struct LocalRepository {
-    repository: Repository,
     path: String,
 }
 
@@ -22,129 +20,94 @@ impl LocalRepository {
             env::current_dir()?
         };
         info!("Repository directory is {}.", path.to_string_lossy());
-        let repository =
-            Repository::open_ext(&path, RepositoryOpenFlags::empty(), vec![] as Vec<String>)
-                .wrap_err("There is no git repository in the current directory.")?;
 
         let path = path.into_os_string().into_string().unwrap();
-        Ok(LocalRepository { repository, path })
+        Ok(LocalRepository { path })
+    }
+
+    #[instrument(skip_all)]
+    fn run(&self, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
+        let command = Command::new("git")
+            .current_dir(&self.path)
+            .args(args)
+            .stdout(if inherit {
+                Stdio::inherit()
+            } else {
+                Stdio::piped()
+            })
+            .stderr(if inherit {
+                Stdio::inherit()
+            } else {
+                Stdio::piped()
+            })
+            .output()?;
+
+        if command.status.success() {
+            let output = String::from_utf8_lossy(&command.stdout).to_string();
+            Ok(output
+                .lines()
+                .map(|s| s.to_string())
+                .collect::<Vec<String>>())
+        } else {
+            Err(eyre!(String::from_utf8_lossy(&command.stderr).to_string()))
+        }
     }
 
     #[instrument(skip_all)]
     pub fn get_branch(self: &LocalRepository) -> Result<String> {
         let head = self
-            .repository
-            .head()
-            .wrap_err("We are not on a branch currently.")?;
-        let branch_shorthand = head
-            .shorthand()
-            .wrap_err("Branch name is not valid UTF-8.")?;
+            .run(vec!["rev-parse", "--abbrev-ref", "HEAD"], false)
+            .wrap_err("Cannot get current branch.")?
+            .into_iter()
+            .next()
+            .filter(|h| h != "HEAD")
+            .wrap_err(eyre!("We are not on a branch currently."))?;
 
-        info!("Current branch is {branch_shorthand}.");
-
-        Ok(branch_shorthand.to_string())
+        info!("Current branch is {head}.");
+        Ok(head)
     }
 
     #[instrument(skip(self))]
-    pub fn get_remote(self: &LocalRepository, remote_name: Option<String>) -> Result<String> {
-        // Use given branch name if we can
-        let remote_name = remote_name
-            // Or fallback to origin, if exists
-            .or_else(|| {
-                self.repository
-                    .find_remote("origin")
-                    .ok()
-                    .and(Some("origin".to_string()))
-            })
-            // Or fallback to the first remote
-            .or_else(|| {
-                self.repository
-                    .remotes()
-                    .into_iter()
-                    .next()
-                    .and_then(|r| r.get(0).map(|b| b.to_string()))
-            })
-            .wrap_err("There are no remotes in the current repository.")?;
-
-        // Find remote URL
-        let remote = self
-            .repository
-            .find_remote(&remote_name)
-            .wrap_err(eyre!("Remote URL with name {} not found.", remote_name))?;
-        let remote_url = remote.url().wrap_err("Remote URL is not valid UTF-8.")?;
-
-        info!("Using remote {remote_name} with url {remote_url}.");
-
-        Ok(remote_url.to_string())
-    }
-
-    #[instrument(skip(self))]
-    pub fn get_remote_branch(
+    pub fn get_parsed_remote(
         self: &LocalRepository,
         branch_name: Option<String>,
-    ) -> Result<(String, String)> {
+    ) -> Result<(String, String, String)> {
         let branch_name = if let Some(branch_name) = branch_name {
             branch_name
         } else {
             self.get_branch()?
         };
 
-        let branch = self
-            .repository
-            .find_branch(&branch_name, BranchType::Local)
-            .wrap_err(eyre!("Branch {} not found.", &branch_name))?;
-        let upstream_branch = branch.upstream().wrap_err(eyre!(
-            "Branch {} doesn't have an upstream branch.",
-            &branch_name
-        ))?;
-        let upstream_branch_name = upstream_branch
-            .name()?
-            .wrap_err("Remote branch name is not valid UTF-8.")?;
-        let (remote_name, remote_branch) = upstream_branch_name.split_once('/').wrap_err(eyre!(
-            "Remote branch name {} is invalid.",
-            upstream_branch_name
-        ))?;
+        // Get remote name
+        let remote_name = self
+            .run(
+                vec!["config", &format!("branch.{branch_name}.remote")],
+                false,
+            )
+            .wrap_err(eyre!("Branch {} not found.", &branch_name))?
+            .into_iter()
+            .next()
+            .wrap_err(eyre!(
+                "Branch {} doesn't have an upstream branch.",
+                &branch_name
+            ))?;
 
-        let remote_url = self.get_remote(Some(remote_name.to_string()))?;
+        // Find remote URL
+        let remote_url = self
+            .run(vec!["remote", "get-url", &remote_name], false)
+            .wrap_err(eyre!("Cannot get remote for {remote_name}."))?
+            .into_iter()
+            .next()
+            .wrap_err(eyre!("Cannot get URL for {remote_name}."))?;
 
-        debug!("Using remote {remote_name} with url {remote_url}.");
+        info!("Using remote {remote_name} with url {remote_url}.");
 
-        Ok((remote_url.to_string(), remote_branch.to_string()))
-    }
-
-    #[instrument(skip(self))]
-    pub fn pull(self: &LocalRepository, output: bool) -> Result<()> {
-        debug!("Git pulling in {}.", &self.path);
-        let mut child = Command::new("git")
-            .args(["-C", &self.path, "pull"])
-            .stdout(if output {
-                Stdio::inherit()
-            } else {
-                Stdio::null()
-            })
-            .stderr(if output {
-                Stdio::inherit()
-            } else {
-                Stdio::null()
-            })
-            .spawn()
-            .wrap_err("Git pull failed to start.")?;
-
-        child.wait().wrap_err("Git pull failed to end.")?;
-
-        Ok(())
+        parse_url(&remote_url).map(|(host, repo)| (host, repo, branch_name))
     }
 
     #[instrument(skip(self))]
     pub fn delete_branch(self: &LocalRepository, branch_name: String) -> Result<()> {
-        let mut branch = self
-            .repository
-            .find_branch(&branch_name, BranchType::Local)
-            .wrap_err(eyre!("Branch {} not found.", &branch_name))?;
-
-        branch
-            .delete()
-            .wrap_err(eyre!("Cannot delete local branch {}.", &branch_name))?;
+        self.run(vec!["branch", "-d", &branch_name], false)?;
 
         Ok(())
     }
@@ -155,44 +118,23 @@ impl LocalRepository {
         branch_name: Option<String>,
         target_name: String,
     ) -> Result<Vec<String>> {
-        // Find all commit OIDs on target
-        let target = self
-            .repository
-            .find_branch(&target_name, BranchType::Local)
-            .wrap_err(eyre!("Branch {} not found.", &target_name))?;
-        let target_commit = target.get().peel_to_commit()?;
-
-        let mut revwalk_target = self.repository.revwalk()?;
-        revwalk_target.set_sorting(Sort::TOPOLOGICAL)?;
-
-        revwalk_target.push(target_commit.id())?;
-
-        // Collect the OIDs of the commits on target for quick retrieval
-        let target_oids: HashSet<Oid> = revwalk_target.filter_map(|oid| oid.ok()).collect();
-
-        // Find all commits on branch but not on target
-        let mut revwalk_branch = self.repository.revwalk()?;
-        revwalk_branch.set_sorting(Sort::TOPOLOGICAL)?;
-
-        if let Some(branch_name) = branch_name {
-            let branch = self
-                .repository
-                .find_branch(&branch_name, BranchType::Local)
-                .wrap_err(eyre!("Branch {} not found.", &branch_name))?;
-            let branch_commit = branch.get().peel_to_commit()?;
-
-            revwalk_branch.push(branch_commit.id())?;
+        let branch_name = if let Some(branch_name) = branch_name {
+            branch_name
         } else {
-            revwalk_branch.push_head()?;
-        }
+            self.get_branch()?
+        };
 
-        // Get messages from the commits on branch not on target
-        let messages: Vec<String> = revwalk_branch
-            .filter_map(|oid| oid.ok())
-            .filter(|oid| !target_oids.contains(oid))
-            .filter_map(|oid| self.repository.find_commit(oid).ok())
-            .filter_map(|commit| commit.summary().map(|s| s.to_string()))
-            .collect();
+        // Find all commit summaries between the two branches
+        let messages = self
+            .run(
+                vec![
+                    "log",
+                    &format!("{target_name}..{branch_name}"),
+                    "--pretty=%s",
+                ],
+                false,
+            )
+            .wrap_err(eyre!("Branch {} not found.", &target_name))?;
 
         Ok(messages)
     }
@@ -203,31 +145,10 @@ impl LocalRepository {
         target_branch: String,
         output: bool,
     ) -> Result<()> {
-        let branch = self
-            .repository
-            .find_branch(&target_branch, BranchType::Local)
-            .wrap_err(eyre!("Branch {} not found.", &target_branch))?;
+        self.run(vec!["checkout", &target_branch], false)?;
 
-        let reference = branch.get();
-        let object = reference.peel(ObjectType::Any).wrap_err(eyre!(
-            "Cannot unwrap reference for branch {}.",
-            &target_branch
-        ))?;
-
-        debug!("Checking out the tree on branch {}", &target_branch);
-        self.repository
-            .checkout_tree(&object, None)
-            .wrap_err(eyre!("Cannot checkout to branch {}.", &target_branch))?;
-
-        let refname = reference
-            .name()
-            .wrap_err("Remote branch name is not valid UTF-8.")?;
-        debug!("Setting the head on branch {}", &target_branch);
-        self.repository
-            .set_head(refname)
-            .wrap_err(eyre!("Cannot checkout to branch {}.", &target_branch))?;
-
-        self.pull(output)?;
+        debug!("Git pulling in {}.", &self.path);
+        self.run(vec!["pull"], output)?;
 
         Ok(())
     }

--- a/src/git/git.rs
+++ b/src/git/git.rs
@@ -1,7 +1,4 @@
-use color_eyre::{
-    eyre::{eyre, Context, ContextCompat},
-    Result,
-};
+use eyre::{eyre, Context, ContextCompat, Result};
 use git2::{BranchType, ObjectType, Oid, Repository, RepositoryOpenFlags, Sort};
 use std::{
     collections::HashSet,

--- a/src/git/url.rs
+++ b/src/git/url.rs
@@ -1,7 +1,4 @@
-use color_eyre::{
-    eyre::{eyre, ContextCompat},
-    Result,
-};
+use eyre::{eyre, ContextCompat, Result};
 use tracing::{debug, instrument};
 
 #[instrument(skip_all)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,27 +13,26 @@ use std::process;
 use tracing::error;
 use utils::tracing::init_tracing;
 
-async fn run(mut args: Cli) -> Result<()> {
+fn run(mut args: Cli) -> Result<()> {
     let conf = Configuration::parse()?;
 
     match args.command {
-        Commands::Login { .. } => login(args, conf).await,
-        Commands::Pr(PrCommands::Create { .. }) => create(args, conf).await,
-        Commands::Pr(PrCommands::Get { .. }) => get(args, conf).await,
+        Commands::Login { .. } => login(args, conf),
+        Commands::Pr(PrCommands::Create { .. }) => create(args, conf),
+        Commands::Pr(PrCommands::Get { .. }) => get(args, conf),
         Commands::Pr(PrCommands::Open { .. }) => {
             args.command = Commands::Pr(PrCommands::Get { open: true });
-            get(args, conf).await
+            get(args, conf)
         }
-        Commands::Pr(PrCommands::List { .. }) => list(args, conf).await,
-        Commands::Pr(PrCommands::Approve { .. }) => approve(args, conf).await,
-        Commands::Pr(PrCommands::Merge { .. }) => merge(args, conf).await,
-        Commands::Pr(PrCommands::Close { .. }) => close(args, conf).await,
+        Commands::Pr(PrCommands::List { .. }) => list(args, conf),
+        Commands::Pr(PrCommands::Approve { .. }) => approve(args, conf),
+        Commands::Pr(PrCommands::Merge { .. }) => merge(args, conf),
+        Commands::Pr(PrCommands::Close { .. }) => close(args, conf),
         Commands::Completion { .. } => Err(eyre!("Invalid command.")),
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let args = Cli::parse_args();
     let Cli {
         output, verbose, ..
@@ -41,7 +40,7 @@ async fn main() -> Result<()> {
 
     init_tracing(verbose, output)?;
 
-    match run(args).await {
+    match run(args) {
         Ok(_) => Ok(()),
         Err(err) => match output {
             _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,12 @@ mod cmd;
 mod utils;
 
 use cmd::{
-    args::{Cli, Commands, OutputType, PrCommands},
+    args::{Cli, Commands, PrCommands},
     config::Configuration,
     login::login::login,
     pr::{approve::approve, close::close, create::create, get::get, list::list, merge::merge},
 };
-use color_eyre::eyre::eyre;
-use color_eyre::Result;
+use eyre::{eyre, Result};
 use std::process;
 use tracing::error;
 use utils::tracing::init_tracing;
@@ -44,12 +43,15 @@ fn main() -> Result<()> {
         Ok(_) => Ok(()),
         Err(err) => match output {
             _ => {
-                if verbose == 0 || output == OutputType::Json {
-                    error!("{}", err.to_string());
-                    process::exit(1)
-                } else {
-                    Err(err)
+                match verbose {
+                    0 => error!("{}", err),
+                    _ => {
+                        for err in err.chain() {
+                            error!("{}", err);
+                        }
+                    }
                 }
+                process::exit(1)
             }
         },
     }

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -1,8 +1,9 @@
 use crate::cmd::args::OutputType;
 use color_eyre::Result;
 use std::env;
+use tracing::metadata::LevelFilter;
 use tracing_error::ErrorLayer;
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tracing_subscriber::{fmt, prelude::*};
 
 pub fn init_tracing(verbosity: u8, output: OutputType) -> Result<()> {
     if env::var("RUST_SPANTRACE").is_err() {
@@ -19,12 +20,12 @@ pub fn init_tracing(verbosity: u8, output: OutputType) -> Result<()> {
     // Set error layer and filter all traces except ours
     let subscriber = tracing_subscriber::registry()
         .with(ErrorLayer::default())
-        .with(EnvFilter::from(match verbosity {
-            1 => "gr=info",
-            2 => "gr=debug",
-            3 => "gr=trace",
-            _ => "gr=error",
-        }));
+        .with(match verbosity {
+            1 => LevelFilter::INFO,
+            2 => LevelFilter::DEBUG,
+            3 => LevelFilter::TRACE,
+            _ => LevelFilter::ERROR,
+        });
 
     // Select output to JSON, or leave it regular
     if output == OutputType::Json {

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -1,5 +1,5 @@
 use crate::cmd::args::OutputType;
-use color_eyre::Result;
+use eyre::Result;
 use std::env;
 use tracing::metadata::LevelFilter;
 use tracing_error::ErrorLayer;
@@ -13,9 +13,9 @@ pub fn init_tracing(verbosity: u8, output: OutputType) -> Result<()> {
         env::set_var("RUST_BACKTRACE", if verbosity == 3 { "1" } else { "0" });
     }
 
-    color_eyre::config::HookBuilder::default()
-        .display_env_section(false)
-        .install()?;
+    // color_eyre::config::HookBuilder::default()
+    //     .display_env_section(false)
+    //     .install()?;
 
     // Set error layer and filter all traces except ours
     let subscriber = tracing_subscriber::registry()

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -4,11 +4,7 @@ use super::common::{
     PullRequestStateFilter, User, VersionControl, VersionControlSettings,
 };
 use base64::{engine::general_purpose::STANDARD_NO_PAD as base64, Engine as _};
-use color_eyre::{
-    eyre::eyre,
-    eyre::{Context, ContextCompat},
-    Result,
-};
+use eyre::{eyre, Context, ContextCompat, Result};
 use native_tls::TlsConnector;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -3,7 +3,6 @@ use super::common::{
     CreatePullRequest, ListPullRequestFilters, PullRequest, PullRequestState,
     PullRequestStateFilter, User, VersionControl, VersionControlSettings,
 };
-use base64::{engine::general_purpose::STANDARD_NO_PAD as base64, Engine as _};
 use eyre::{eyre, Context, ContextCompat, Result};
 use native_tls::TlsConnector;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -246,7 +245,7 @@ impl Bitbucket {
 
         let request = self.client.request(method, &url).set(
             "Authorization",
-            &format!("Basic {}", base64.encode(format!("{username}:{password}"))),
+            &format!("Basic {}", base64::encode(format!("{username}:{password}"))),
         );
         let result = if let Some(body) = &body {
             trace!("Sending body: {}.", serde_json::to_string(&body)?);

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -4,7 +4,6 @@ use super::common::{
     PullRequestStateFilter, User, VersionControl, VersionControlSettings,
 };
 use base64::{engine::general_purpose::STANDARD_NO_PAD as base64, Engine as _};
-use chrono::{DateTime, Utc};
 use color_eyre::{
     eyre::eyre,
     eyre::{Context, ContextCompat},
@@ -13,6 +12,7 @@ use color_eyre::{
 use native_tls::TlsConnector;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
+use time::OffsetDateTime;
 use tracing::{info, instrument, trace};
 use ureq::{Agent, AgentBuilder};
 
@@ -112,8 +112,10 @@ pub struct BitbucketPullRequest {
     pub title: String,
     pub description: String,
     pub links: BitbucketPullRequestLinks,
-    pub created_on: DateTime<Utc>,
-    pub updated_on: DateTime<Utc>,
+    #[serde(with = "time::serde::iso8601")]
+    pub created_on: OffsetDateTime,
+    #[serde(with = "time::serde::iso8601")]
+    pub updated_on: OffsetDateTime,
     pub source: BitbucketPullRequestRevision,
     pub destination: BitbucketPullRequestRevision,
     pub author: BitbucketUser,

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -1,7 +1,7 @@
-use chrono::{DateTime, Utc};
 use color_eyre::Result;
 use open::that as open_in_browser;
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 use crate::formatters::formatter::{Formatter, FormatterType};
 use crate::vcs::{bitbucket::Bitbucket, github::GitHub, gitlab::GitLab};
@@ -29,8 +29,10 @@ pub struct PullRequest {
     pub source: String,
     pub target: String,
     pub url: String,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    #[serde(with = "time::serde::iso8601")]
+    pub created_at: OffsetDateTime,
+    #[serde(with = "time::serde::iso8601")]
+    pub updated_at: OffsetDateTime,
     pub author: User,
     pub closed_by: Option<User>,
     pub reviewers: Option<Vec<User>>,

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -1,4 +1,4 @@
-use color_eyre::Result;
+use eyre::Result;
 use open::that as open_in_browser;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use color_eyre::Result;
 use open::that as open_in_browser;
@@ -86,20 +85,19 @@ pub struct VersionControlSettings {
     pub vcs_type: Option<String>,
     pub default_branch: Option<String>,
 }
-#[async_trait]
 pub trait VersionControl {
     fn init(hostname: String, repo: String, settings: VersionControlSettings) -> Self
     where
         Self: Sized;
     fn login_url(&self) -> String;
     fn validate_token(&self, token: &str) -> Result<()>;
-    async fn create_pr(&self, pr: CreatePullRequest) -> Result<PullRequest>;
-    async fn get_pr_by_id(&self, id: u32) -> Result<PullRequest>;
-    async fn get_pr_by_branch(&self, branch: &str) -> Result<PullRequest>;
-    async fn list_prs(&self, filters: ListPullRequestFilters) -> Result<Vec<PullRequest>>;
-    async fn approve_pr(&self, id: u32) -> Result<()>;
-    async fn close_pr(&self, id: u32) -> Result<PullRequest>;
-    async fn merge_pr(&self, id: u32, delete_source_branch: bool) -> Result<PullRequest>;
+    fn create_pr(&self, pr: CreatePullRequest) -> Result<PullRequest>;
+    fn get_pr_by_id(&self, id: u32) -> Result<PullRequest>;
+    fn get_pr_by_branch(&self, branch: &str) -> Result<PullRequest>;
+    fn list_prs(&self, filters: ListPullRequestFilters) -> Result<Vec<PullRequest>>;
+    fn approve_pr(&self, id: u32) -> Result<()>;
+    fn close_pr(&self, id: u32) -> Result<PullRequest>;
+    fn merge_pr(&self, id: u32, delete_source_branch: bool) -> Result<PullRequest>;
 }
 
 pub fn init_vcs(

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -3,10 +3,7 @@ use super::common::{
     CreatePullRequest, ListPullRequestFilters, PullRequest, PullRequestState,
     PullRequestStateFilter, User, VersionControl, VersionControlSettings,
 };
-use color_eyre::{
-    eyre::{eyre, Context},
-    Result,
-};
+use eyre::{eyre, Context, Result};
 use native_tls::TlsConnector;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -4,11 +4,15 @@ use super::common::{
     PullRequestStateFilter, User, VersionControl, VersionControlSettings,
 };
 use chrono::{DateTime, Utc};
-use color_eyre::{eyre::{eyre, Context}, Result};
+use color_eyre::{
+    eyre::{eyre, Context},
+    Result,
+};
+use native_tls::TlsConnector;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 use tracing::{info, instrument, trace};
-use ureq::Agent;
+use ureq::{Agent, AgentBuilder};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GitHubUser {
@@ -252,7 +256,9 @@ impl GitHub {
 impl VersionControl for GitHub {
     #[instrument(skip_all)]
     fn init(_: String, repo: String, settings: VersionControlSettings) -> Self {
-        let client = Agent::new();
+        let client = AgentBuilder::new()
+            .tls_connector(Arc::new(TlsConnector::new().unwrap()))
+            .build();
         GitHub {
             settings,
             client,

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -3,7 +3,6 @@ use super::common::{
     CreatePullRequest, ListPullRequestFilters, PullRequest, PullRequestState,
     PullRequestStateFilter, User, VersionControl, VersionControlSettings,
 };
-use chrono::{DateTime, Utc};
 use color_eyre::{
     eyre::{eyre, Context},
     Result,
@@ -11,6 +10,7 @@ use color_eyre::{
 use native_tls::TlsConnector;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
+use time::OffsetDateTime;
 use tracing::{info, instrument, trace};
 use ureq::{Agent, AgentBuilder};
 
@@ -38,8 +38,10 @@ struct GitHubRepository {
     owner: GitHubUser,
     html_url: String,
     description: Option<String>,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
+    #[serde(with = "time::serde::iso8601")]
+    created_at: OffsetDateTime,
+    #[serde(with = "time::serde::iso8601")]
+    updated_at: OffsetDateTime,
     stargazers_count: u32,
     archived: bool,
     disabled: bool,
@@ -71,9 +73,12 @@ pub struct GitHubPullRequest {
     pub head: GitHubPullRequestBranch,
     pub base: GitHubPullRequestBranch,
     pub html_url: String,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-    pub merged_at: Option<DateTime<Utc>>,
+    #[serde(with = "time::serde::iso8601")]
+    pub created_at: OffsetDateTime,
+    #[serde(with = "time::serde::iso8601")]
+    pub updated_at: OffsetDateTime,
+    #[serde(with = "time::serde::iso8601::option")]
+    pub merged_at: Option<OffsetDateTime>,
     pub user: GitHubUser,
     pub merged_by: Option<GitHubUser>,
     pub requested_reviewers: Option<Vec<GitHubUser>>,

--- a/src/vcs/gitlab.rs
+++ b/src/vcs/gitlab.rs
@@ -3,8 +3,8 @@ use super::common::{
     CreatePullRequest, ListPullRequestFilters, PullRequest, PullRequestState,
     PullRequestStateFilter, PullRequestUserFilter, User, VersionControl, VersionControlSettings,
 };
-use color_eyre::{
-    eyre::{eyre, Context},
+use eyre::{
+    eyre, Context,
     Result,
 };
 use native_tls::TlsConnector;

--- a/src/vcs/gitlab.rs
+++ b/src/vcs/gitlab.rs
@@ -8,10 +8,11 @@ use color_eyre::{
     eyre::{eyre, Context},
     Result,
 };
+use native_tls::TlsConnector;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 use tracing::{info, instrument, trace};
-use ureq::Agent;
+use ureq::{Agent, AgentBuilder};
 use urlencoding::encode;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -281,7 +282,9 @@ impl GitLab {
 impl VersionControl for GitLab {
     #[instrument(skip_all)]
     fn init(hostname: String, repo: String, settings: VersionControlSettings) -> Self {
-        let client = Agent::new();
+        let client = AgentBuilder::new()
+            .tls_connector(Arc::new(TlsConnector::new().unwrap()))
+            .build();
         GitLab {
             settings,
             client,

--- a/src/vcs/gitlab.rs
+++ b/src/vcs/gitlab.rs
@@ -3,7 +3,6 @@ use super::common::{
     CreatePullRequest, ListPullRequestFilters, PullRequest, PullRequestState,
     PullRequestStateFilter, PullRequestUserFilter, User, VersionControl, VersionControlSettings,
 };
-use chrono::{DateTime, Utc};
 use color_eyre::{
     eyre::{eyre, Context},
     Result,
@@ -11,6 +10,7 @@ use color_eyre::{
 use native_tls::TlsConnector;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
+use time::OffsetDateTime;
 use tracing::{info, instrument, trace};
 use ureq::{Agent, AgentBuilder};
 use urlencoding::encode;
@@ -51,7 +51,8 @@ struct GitLabRepository {
     path: String,
     path_with_namespace: String,
     description: String,
-    created_at: DateTime<Utc>,
+    #[serde(with = "time::serde::iso8601")]
+    created_at: OffsetDateTime,
     default_branch: String,
     web_url: String,
     forks_count: u32,
@@ -95,8 +96,10 @@ pub struct GitLabPullRequest {
     pub source_branch: String,
     pub target_branch: String,
     pub web_url: String,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
+    #[serde(with = "time::serde::iso8601")]
+    pub created_at: OffsetDateTime,
+    #[serde(with = "time::serde::iso8601")]
+    pub updated_at: OffsetDateTime,
     pub author: GitLabUser,
     pub closed_by: Option<GitLabUser>,
     pub reviewers: Option<Vec<GitLabUser>>,


### PR DESCRIPTION
- Remove duplicate base64
- Change back the tracing-subscriber features
- Remove git2 in favour of manual git parsing
- Remove features from tracing subscriber
- Remove color eyre in favour of eyre
- Move to smaller time library
- Change ureq TLS to native-tls
- Remove env filter from tracing
- Remove unnecessary libraries, flags
- Replace reqwest with ureq
- Remove async from the code altogether
- Remove vendored libraries to improve performance
