### PR TITLE
Add repository creation and forking commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           command: clippy
           args: -- -Dwarnings
       - name: Install nextest for testing
-        uses: actions-rs/install@v1
+        uses: actions-rs/install@v0.1
         with:
           crate: cargo-nextest
           use-tool-cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,9 +53,11 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --test '*' -- --nocapture
+          args: --test 'github_repo' -- --nocapture
         env:
           RUST_BACKTRACE: 1
+          GIT_SSH_COMMAND: "ssh -vv"
+          GIT_TRACE: 1
   release:
     name: Release if we are on a tag
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           command: clippy
           args: -- -Dwarnings
+      - name: Install nextest for testing
+        uses: actions-rs/install@v1
+        with:
+          crate: cargo-nextest
+          use-tool-cache: true
       - name: Setup configuration files
         run: |
           git config --global user.email "gr-test@d7gr.net"
@@ -52,8 +57,8 @@ jobs:
       - name: Run integration tests
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --test '*' -- --nocapture
+          command: nextest
+          args: run
         env:
           RUST_BACKTRACE: 1
   release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -Dwarnings
       - name: Setup configuration files
         run: |
           git config --global user.email "gr-test@d7gr.net"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --test 'github_repo' -- --nocapture
+          args: --test 'repo-github' -- --nocapture
         env:
           RUST_BACKTRACE: 1
           GIT_SSH_COMMAND: "ssh -vv"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,6 @@ jobs:
         with:
           command: clippy
           args: -- -Dwarnings
-      - name: Install nextest for testing
-        uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-nextest
-          use-tool-cache: true
       - name: Setup configuration files
         run: |
           git config --global user.email "gr-test@d7gr.net"
@@ -57,8 +52,8 @@ jobs:
       - name: Run integration tests
         uses: actions-rs/cargo@v1
         with:
-          command: nextest
-          args: run
+          command: test
+          args: --test '*' -- --nocapture
         env:
           RUST_BACKTRACE: 1
   release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,11 +53,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --test 'repo-github' -- --nocapture
+          args: --test '*' -- --nocapture
         env:
           RUST_BACKTRACE: 1
-          GIT_SSH_COMMAND: "ssh -vv"
-          GIT_TRACE: 1
   release:
     name: Release if we are on a tag
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 -   Allow type to be defined at login
 -   Add Gitea integration
+-   Allow repository creation and forking with repo subcommand
+-   Add hidden repository delete command to repo
 
 ## [0.1.5] - 2023-03-22
 

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -169,6 +169,60 @@ $ gr pr decline")]
 }
 
 #[derive(Debug, Subcommand)]
+#[command(after_help = "Examples:
+
+Create new repository:
+$ gr repo new 
+
+Fork a repository:
+$ gr repo fork https://github.com/daniel7grant/gr
+
+Get information about the current repository:
+$ gr repo get
+")]
+pub enum RepoCommands {
+    #[command(after_help = "Examples:
+
+Get the repository information in the current directory:
+$ gr repo new 
+")]
+    /// Create new repository
+    New {
+        repository: String,
+    },
+    #[command(after_help = "Examples:
+
+Get the repository information in the current directory:
+$ gr repo new 
+")]
+    /// Fork existing repository
+    Fork {
+        repository: String,
+    },
+    #[command(after_help = "Examples:
+
+Get the repository information in the current directory:
+$ gr repo get
+
+Open repository in the browser:
+$ gr repo get --open
+")]
+    /// Get the open repository
+    Get {
+        /// Open the repository in the browser
+        #[arg(long)]
+        open: bool,
+    },
+    #[command(after_help = "Examples:
+
+Open repository in the browser:
+$ gr repo open
+")]
+    /// Open the repository in the browser
+    Open {},
+}
+
+#[derive(Debug, Subcommand)]
 pub enum Commands {
     #[command(after_help = "Examples:
 
@@ -188,9 +242,12 @@ $ gr login github.com")]
         #[arg(long)]
         token: Option<String>,
     },
-    /// Interact with pull requests
+    /// Open, list and merge pull requests
     #[command(subcommand)]
     Pr(PrCommands),
+    /// Fork or create repositories
+    #[command(subcommand)]
+    Repo(RepoCommands),
     /// Generate tab completion to shell
     Completion { shell: Shell },
 }

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -94,10 +94,7 @@ Create a pull request to merge into a different branch:
 $ gr pr create -m 'Do things' --target staging
 
 Create a pull request and merge it immediately (for fix branches):
-$ gr pr create -m 'Fix things' --merge --delete
-
-Create a pull request to the forked repository:
-$ gr pr create -m 'Fix things for you' --fork")]
+$ gr pr create -m 'Fix things' --merge --delete")]
     /// Create pull request for the current branch
     ///
     /// The only required field is the title (--message / -m), other fields will be filled by sane defaults:
@@ -124,9 +121,6 @@ $ gr pr create -m 'Fix things for you' --fork")]
         /// Merge the pull request instantly (good for hotfixes)
         #[arg(long)]
         merge: bool,
-        /// Create the pull request for the fork
-        #[arg(long)]
-        fork: bool,
     },
     #[command(after_help = "Examples:
 

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -203,6 +203,7 @@ Get information about the current repository:
 $ gr repo get
 ")]
 pub enum RepoCommands {
+	#[command(alias = "create")]
     #[command(after_help = "Examples:
 
 Create new repository (and push the current dir if it has a git repository):
@@ -216,14 +217,13 @@ $ gr repo new new-repo --clone
 
 Create new repo and clone somewhere else:
 $ gr repo new new-repo --clone --dir path/to/another
+
+Create new repository and initialize with (all options):
+$ gr repo new new-repo --init --default-branch develop --gitignore Rust --license MIT
 ")]
     /// Create new repository
     New {
-        /// The name of the new repository
-        /// Can be either:
-        /// - a full URL, e.g. "https://github.com/user/gr.git"
-        /// - an organization and repo name, e.g. "user/gr"
-        /// - or a repo name (will be created under user) e.g. "gr"
+        /// The name of the new repository, can be either: a full URL (e.g. "https://github.com/user/gr.git"), an organization and repo name, (e.g. "user/gr") or a repo name (will be created under user) e.g. "gr".
         repository: String,
         /// The host of the server (e.g. "github.com")
         #[arg(long)]
@@ -237,6 +237,18 @@ $ gr repo new new-repo --clone --dir path/to/another
         /// The visibility of the new repo
         #[arg(long, default_value = "private")]
         visibility: Visibility,
+        /// Whether to initialize the repository with a README (GitHub, GitLab and Gitea only)
+        #[arg(long)]
+		init: bool,
+        /// The default branch to initialize with (GitLab and Gitea only)
+        #[arg(long)]
+        default_branch: Option<String>,
+        /// The gitignore to initialize with (GitHub and Gitea only)
+        #[arg(long)]
+        gitignore: Option<String>,
+        /// The license to initialize with (GitHub and Gitea only)
+        #[arg(long)]
+        license: Option<String>,
         /// Whether to open the new repository in the browser
         #[arg(long)]
 		open: bool,

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -94,7 +94,10 @@ Create a pull request to merge into a different branch:
 $ gr pr create -m 'Do things' --target staging
 
 Create a pull request and merge it immediately (for fix branches):
-$ gr pr create -m 'Fix things' --merge --delete")]
+$ gr pr create -m 'Fix things' --merge --delete
+
+Create a pull request to the forked repository:
+$ gr pr create -m 'Fix things for you' --fork")]
     /// Create pull request for the current branch
     ///
     /// The only required field is the title (--message / -m), other fields will be filled by sane defaults:
@@ -121,6 +124,9 @@ $ gr pr create -m 'Fix things' --merge --delete")]
         /// Merge the pull request instantly (good for hotfixes)
         #[arg(long)]
         merge: bool,
+        /// Create the pull request for the fork
+        #[arg(long)]
+        fork: bool,
     },
     #[command(after_help = "Examples:
 

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -235,7 +235,7 @@ $ gr repo new new-repo --clone --dir path/to/another
         #[arg(short, long)]
         description: Option<String>,
         /// The visibility of the new repo
-        #[arg(long, default_value = "public")]
+        #[arg(long, default_value = "private")]
         visibility: Visibility,
     },
     #[command(after_help = "Examples:

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -203,7 +203,7 @@ Get information about the current repository:
 $ gr repo get
 ")]
 pub enum RepoCommands {
-	#[command(alias = "create")]
+    #[command(alias = "create")]
     #[command(after_help = "Examples:
 
 Create new repository (and push the current dir if it has a git repository):
@@ -239,7 +239,7 @@ $ gr repo new new-repo --init --default-branch develop --gitignore Rust --licens
         visibility: Visibility,
         /// Whether to initialize the repository with a README (GitHub, GitLab and Gitea only)
         #[arg(long)]
-		init: bool,
+        init: bool,
         /// The default branch to initialize with (GitLab and Gitea only)
         #[arg(long)]
         default_branch: Option<String>,
@@ -251,7 +251,7 @@ $ gr repo new new-repo --init --default-branch develop --gitignore Rust --licens
         license: Option<String>,
         /// Whether to open the new repository in the browser
         #[arg(long)]
-		open: bool,
+        open: bool,
     },
     #[command(after_help = "Examples:
     
@@ -295,17 +295,20 @@ $ gr repo open
 ")]
     /// Open the repository in the browser
     Open {},
-    #[command(hide = true, after_help = "Examples:
+    #[command(
+        hide = true,
+        after_help = "Examples:
 
 Delete the current repository:
 $ gr repo delete
-")]
-	/// Delete the current repository
-	Delete {
-		/// Delete the repository FOREVER without interaction
-		#[arg(long = "yes-delete-permanently")]
-		force: bool,
-	},
+"
+    )]
+    /// Delete the current repository
+    Delete {
+        /// Delete the repository FOREVER without interaction
+        #[arg(long = "yes-delete-permanently")]
+        force: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -237,6 +237,9 @@ $ gr repo new new-repo --clone --dir path/to/another
         /// The visibility of the new repo
         #[arg(long, default_value = "private")]
         visibility: Visibility,
+        /// Whether to open the new repository in the browser
+        #[arg(long)]
+		open: bool,
     },
     #[command(after_help = "Examples:
     

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -205,8 +205,17 @@ $ gr repo get
 pub enum RepoCommands {
     #[command(after_help = "Examples:
 
-Create new repository:
+Create new repository (and push the current dir if it has a git repository):
 $ gr repo new new-repo
+
+Create new repository for a specific remote:
+$ gr repo new new-repo --host github.com
+
+Create new repo and clone it immediately:
+$ gr repo new new-repo --clone
+
+Create new repo and clone somewhere else:
+$ gr repo new new-repo --clone --dir path/to/another
 ")]
     /// Create new repository
     New {
@@ -219,6 +228,9 @@ $ gr repo new new-repo
         /// The host of the server (e.g. "github.com")
         #[arg(long)]
         host: Option<String>,
+        /// Whether to clone the new repository
+        #[arg(long)]
+        clone: bool,
         /// The description of the new repo
         #[arg(short, long)]
         description: Option<String>,

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -242,9 +242,20 @@ $ gr repo new new-repo --clone --dir path/to/another
     
 Fork an existing repository:
 $ gr repo fork https://github.com/daniel7grant/gr
+
+Fork an existing repository to a different name:
+$ gr repo fork https://github.com/daniel7grant/gr gr_forked
+
+Fork an existing repository to a different organization:
+$ gr repo fork https://github.com/daniel7grant/gr organization/gr
 ")]
     /// Fork existing repository
-    Fork { repository: String },
+    Fork {
+        /// The source repository to fork from
+        source: String,
+        /// The target name, e.g. "name" or "org/name" (by default the same name to the current user)
+        repository: Option<String>,
+    },
     #[command(after_help = "Examples:
 
 Get the repository information in the current directory:

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -1,6 +1,7 @@
 use clap::{ArgAction, Command, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{generate, Generator, Shell};
 use gr_bin::formatters::formatter::FormatterType;
+use gr_bin::vcs::common::RepositoryVisibility;
 use std::io;
 use std::process;
 
@@ -40,6 +41,27 @@ impl From<OutputType> for FormatterType {
         match val {
             OutputType::Normal => FormatterType::Normal,
             OutputType::Json => FormatterType::Json,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Default)]
+pub enum Visibility {
+    /// Repo can be visible by anyone (default)
+    #[default]
+    Public,
+    /// Repo can only be visible by you
+    Private,
+    /// Repo can only be visible by logged in users (GitLab only)
+    Internal,
+}
+
+impl From<Visibility> for RepositoryVisibility {
+    fn from(val: Visibility) -> Self {
+        match val {
+            Visibility::Public => RepositoryVisibility::Public,
+            Visibility::Private => RepositoryVisibility::Private,
+            Visibility::Internal => RepositoryVisibility::Internal,
         }
     }
 }
@@ -187,7 +209,23 @@ Create new repository:
 $ gr repo new new-repo
 ")]
     /// Create new repository
-    New { repository: String },
+    New {
+        /// The name of the new repository
+        /// Can be either:
+        /// - a full URL, e.g. "https://github.com/user/gr.git"
+        /// - an organization and repo name, e.g. "user/gr"
+        /// - or a repo name (will be created under user) e.g. "gr"
+        repository: String,
+        /// The host of the server (e.g. "github.com")
+        #[arg(long)]
+        host: Option<String>,
+        /// The description of the new repo
+        #[arg(short, long)]
+        description: Option<String>,
+        /// The visibility of the new repo
+        #[arg(long, default_value = "public")]
+        visibility: Visibility,
+    },
     #[command(after_help = "Examples:
     
 Fork an existing repository:

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -172,7 +172,7 @@ $ gr pr decline")]
 #[command(after_help = "Examples:
 
 Create new repository:
-$ gr repo new 
+$ gr repo new new-repo
 
 Fork a repository:
 $ gr repo fork https://github.com/daniel7grant/gr
@@ -183,22 +183,18 @@ $ gr repo get
 pub enum RepoCommands {
     #[command(after_help = "Examples:
 
-Get the repository information in the current directory:
-$ gr repo new 
+Create new repository:
+$ gr repo new new-repo
 ")]
     /// Create new repository
-    New {
-        repository: String,
-    },
+    New { repository: String },
     #[command(after_help = "Examples:
-
-Get the repository information in the current directory:
-$ gr repo new 
+    
+Fork an existing repository:
+$ gr repo fork https://github.com/daniel7grant/gr
 ")]
     /// Fork existing repository
-    Fork {
-        repository: String,
-    },
+    Fork { repository: String },
     #[command(after_help = "Examples:
 
 Get the repository information in the current directory:

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -295,6 +295,17 @@ $ gr repo open
 ")]
     /// Open the repository in the browser
     Open {},
+    #[command(hide = true, after_help = "Examples:
+
+Delete the current repository:
+$ gr repo delete
+")]
+	/// Delete the current repository
+	Delete {
+		/// Delete the repository FOREVER without interaction
+		#[arg(long = "yes-delete-permanently")]
+		force: bool,
+	},
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/cmd/args.rs
+++ b/src/cmd/args.rs
@@ -258,6 +258,9 @@ $ gr repo fork https://github.com/daniel7grant/gr organization/gr
         source: String,
         /// The target name, e.g. "name" or "org/name" (by default the same name to the current user)
         repository: Option<String>,
+        /// Whether to clone the forked repository
+        #[arg(long)]
+        clone: bool,
     },
     #[command(after_help = "Examples:
 

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -5,10 +5,12 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fs::read_to_string, fs::write};
 use tracing::{info, instrument, trace};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct RepositoryConfig {
     pub auth: Option<String>,
     pub default_branch: Option<String>,
+    #[serde(default)]
+    pub fork: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -97,6 +99,7 @@ impl Configuration {
                 auth: r.and_then(|r| r.auth.clone()).unwrap_or(v.auth.clone()),
                 default_branch: r.and_then(|r| r.default_branch.clone()),
                 vcs_type: v.vcs_type.clone(),
+                fork: r.map(|r| r.fork).unwrap_or_default(),
             }
         })
     }

--- a/src/cmd/login/login.rs
+++ b/src/cmd/login/login.rs
@@ -89,7 +89,7 @@ pub fn login(args: Cli, mut conf: Configuration) -> Result<()> {
                         })
                         .or_insert(RepositoryConfig {
                             auth: Some(token),
-                            default_branch: None,
+                            ..Default::default()
                         });
                 });
             }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,3 +2,4 @@ pub mod args;
 pub mod config;
 pub mod login;
 pub mod pr;
+pub mod repo;

--- a/src/cmd/pr/create.rs
+++ b/src/cmd/pr/create.rs
@@ -28,6 +28,7 @@ pub fn create(args: Cli, mut conf: Configuration) -> Result<()> {
         open,
         reviewers,
         merge,
+        fork,
     }) = command
     {
         let repository = LocalRepository::init(dir)?;
@@ -106,6 +107,7 @@ pub fn create(args: Cli, mut conf: Configuration) -> Result<()> {
             target,
             close_source_branch: delete,
             reviewers: reviewers.unwrap_or_default(),
+            fork,
         })?;
 
         pr.print(open, output.into());

--- a/src/cmd/pr/create.rs
+++ b/src/cmd/pr/create.rs
@@ -28,7 +28,6 @@ pub fn create(args: Cli, mut conf: Configuration) -> Result<()> {
         open,
         reviewers,
         merge,
-        fork,
     }) = command
     {
         let repository = LocalRepository::init(dir)?;
@@ -107,7 +106,6 @@ pub fn create(args: Cli, mut conf: Configuration) -> Result<()> {
             target,
             close_source_branch: delete,
             reviewers: reviewers.unwrap_or_default(),
-            fork,
         })?;
 
         pr.print(open, output.into());
@@ -149,8 +147,8 @@ pub fn create(args: Cli, mut conf: Configuration) -> Result<()> {
                     .entry(repo)
                     .and_modify(|repo| repo.default_branch = Some(pr.target.clone()))
                     .or_insert(RepositoryConfig {
-                        auth: None,
                         default_branch: Some(pr.target.clone()),
+                        ..Default::default()
                     });
             });
 

--- a/src/cmd/repo/delete.rs
+++ b/src/cmd/repo/delete.rs
@@ -73,7 +73,7 @@ pub fn delete(args: Cli, conf: Configuration) -> Result<()> {
 
         vcs.delete_repository()?;
 
-        println!("Repository {} deleted.", repo.full_name );
+        println!("Repository {} deleted.", repo.full_name);
 
         Ok(())
     } else {

--- a/src/cmd/repo/delete.rs
+++ b/src/cmd/repo/delete.rs
@@ -1,0 +1,82 @@
+use std::io::{self, Write};
+
+use crate::cmd::{
+    args::{Cli, Commands, RepoCommands},
+    config::Configuration,
+};
+use colored::Colorize;
+use eyre::{eyre, Context, ContextCompat, Result};
+use gr_bin::vcs::common::init_vcs;
+use gr_bin::{git::git::LocalRepository, vcs::common::VersionControlSettings};
+use tracing::instrument;
+
+#[instrument(skip_all, fields(command = ?args.command))]
+pub fn delete(args: Cli, conf: Configuration) -> Result<()> {
+    let Cli {
+        command,
+        branch,
+        dir,
+        auth,
+        output,
+        verbose: _,
+    } = args;
+    if let Commands::Repo(RepoCommands::Delete { force }) = command {
+        let repository = LocalRepository::init(dir)?;
+        let (hostname, repo, ..) = repository.get_parsed_remote(branch)?;
+
+        // Find settings or use the auth command
+        let settings = conf.find_settings(&hostname, &repo);
+        let settings = if let Some(auth) = auth {
+            VersionControlSettings {
+                auth,
+                ..settings.unwrap_or_default()
+            }
+        } else {
+            settings.wrap_err(eyre!(
+                "Authentication not found for {} in {}.",
+                &hostname,
+                &repo
+            ))?
+        };
+
+        let vcs = init_vcs(hostname, repo, settings)?;
+
+        let repo = vcs.get_repository()?;
+        repo.print(false, output.into());
+
+        if !force {
+            println!(
+                "You are about to {} this repository. {}",
+                "delete".red().bold(),
+                "This action cannot be undone!".bold()
+            );
+            let mut stdout = io::stdout();
+            let stdin = io::stdin();
+            write!(
+                stdout,
+                "Please enter the repository name if you are absolutely sure: "
+            )?;
+            stdout.flush()?;
+            let mut entered_name = String::new();
+            stdin
+                .read_line(&mut entered_name)
+                .wrap_err("Reading the repository name failed.")?;
+            entered_name = entered_name.trim().to_string();
+            if entered_name != repo.full_name {
+                return Err(eyre!(
+                    "You cannot delete {}! You entered: {}.",
+                    repo.full_name,
+                    entered_name
+                ));
+            }
+        }
+
+        vcs.delete_repository()?;
+
+        println!("Repository {} deleted.", repo.full_name );
+
+        Ok(())
+    } else {
+        Err(eyre!("Invalid command!"))
+    }
+}

--- a/src/cmd/repo/fork.rs
+++ b/src/cmd/repo/fork.rs
@@ -2,14 +2,58 @@ use crate::cmd::{
     args::{Cli, Commands, RepoCommands},
     config::Configuration,
 };
-use eyre::{eyre, Result};
+use eyre::{eyre, ContextCompat, Result};
+use gr_bin::{
+    git::url::parse_url,
+    vcs::common::{init_vcs, ForkRepository, VersionControlSettings},
+};
 use tracing::instrument;
 
 #[instrument(skip_all, fields(command = ?args.command))]
-pub fn fork(args: Cli, _: Configuration) -> Result<()> {
-    let Cli { command, .. } = args;
-    if let Commands::Repo(RepoCommands::Fork { .. }) = command {
-        Err(eyre!("Forking repos is not implemented"))
+pub fn fork(args: Cli, conf: Configuration) -> Result<()> {
+    let Cli {
+        command,
+        auth,
+        output,
+        ..
+    } = args;
+    if let Commands::Repo(RepoCommands::Fork {
+        source,
+        repository: repository_name,
+    }) = command
+    {
+        let (hostname, original) = parse_url(&source)?;
+
+        let settings = conf.find_settings(&hostname, &original);
+        let settings = if let Some(auth) = auth {
+            VersionControlSettings {
+                auth,
+                ..settings.unwrap_or_default()
+            }
+        } else {
+            settings.wrap_err(eyre!(
+                "Authentication not found for {} in {}.",
+                &hostname,
+                &original
+            ))?
+        };
+
+        let (organization, name) = repository_name
+            .map(|name| {
+                if let Some((org, name)) = name.split_once('/') {
+                    (Some(org.to_string()), Some(name.to_string()))
+                } else {
+                    (None, Some(name))
+                }
+            })
+            .unwrap_or((None, None));
+
+        let vcs = init_vcs(hostname, original, settings)?;
+        let repo = vcs.fork_repository(ForkRepository { organization, name })?;
+
+        repo.print(false, output.into());
+
+        Ok(())
     } else {
         Err(eyre!("Invalid command!"))
     }

--- a/src/cmd/repo/fork.rs
+++ b/src/cmd/repo/fork.rs
@@ -1,0 +1,16 @@
+use crate::cmd::{
+    args::{Cli, Commands, RepoCommands},
+    config::Configuration,
+};
+use eyre::{eyre, Result};
+use tracing::instrument;
+
+#[instrument(skip_all, fields(command = ?args.command))]
+pub fn fork(args: Cli, _: Configuration) -> Result<()> {
+    let Cli { command, .. } = args;
+    if let Commands::Repo(RepoCommands::Fork { .. }) = command {
+        Err(eyre!("Forking repos is not implemented"))
+    } else {
+        Err(eyre!("Invalid command!"))
+    }
+}

--- a/src/cmd/repo/fork.rs
+++ b/src/cmd/repo/fork.rs
@@ -7,6 +7,7 @@ use gr_bin::{
     git::{git::LocalRepository, url::parse_url},
     vcs::common::{init_vcs, ForkRepository, VersionControlSettings},
 };
+use std::{thread::sleep, time::Duration};
 use tracing::instrument;
 
 #[instrument(skip_all, fields(command = ?args.command))]
@@ -55,9 +56,12 @@ pub fn fork(args: Cli, conf: Configuration) -> Result<()> {
 
         repo.print(false, output.into());
 
-        let repository = LocalRepository::init(dir.clone())?;
         if clone {
+            // Wait for a moment, to let the server finish the fork
+            sleep(Duration::from_millis(500));
+           
             // If clone is given, clone it to the directory (or here)
+            let repository = LocalRepository::init(dir.clone())?;
             repository
                 .clone(repo.ssh_url, dir.clone())
                 .or_else(|_| repository.clone(repo.https_url, dir))?;

--- a/src/cmd/repo/get.rs
+++ b/src/cmd/repo/get.rs
@@ -1,5 +1,5 @@
 use crate::cmd::{
-    args::{Cli, Commands, PrCommands},
+    args::{Cli, Commands, RepoCommands},
     config::Configuration,
 };
 use eyre::{eyre, ContextCompat, Result};
@@ -14,10 +14,10 @@ pub fn get(args: Cli, conf: Configuration) -> Result<()> {
         branch,
         dir,
         auth,
-        output: _,
+        output,
         verbose: _,
     } = args;
-    if let Commands::Pr(PrCommands::Get { .. }) = command {
+    if let Commands::Repo(RepoCommands::Get { open }) = command {
         let repository = LocalRepository::init(dir)?;
         let (hostname, repo, ..) = repository.get_parsed_remote(branch)?;
 
@@ -36,9 +36,11 @@ pub fn get(args: Cli, conf: Configuration) -> Result<()> {
             ))?
         };
 
-        let _ = init_vcs(hostname, repo, settings);
-        
-        Err(eyre!("Getting information about current repo is not implemented"))
+        let vcs = init_vcs(hostname, repo, settings);
+
+        let repo = vcs.get_repository()?;
+        repo.print(open, output.into());
+        Ok(())
     } else {
         Err(eyre!("Invalid command!"))
     }

--- a/src/cmd/repo/get.rs
+++ b/src/cmd/repo/get.rs
@@ -36,7 +36,7 @@ pub fn get(args: Cli, conf: Configuration) -> Result<()> {
             ))?
         };
 
-        let vcs = init_vcs(hostname, repo, settings);
+        let vcs = init_vcs(hostname, repo, settings)?;
 
         let repo = vcs.get_repository()?;
         repo.print(open, output.into());

--- a/src/cmd/repo/get.rs
+++ b/src/cmd/repo/get.rs
@@ -1,0 +1,45 @@
+use crate::cmd::{
+    args::{Cli, Commands, PrCommands},
+    config::Configuration,
+};
+use eyre::{eyre, ContextCompat, Result};
+use gr_bin::vcs::common::init_vcs;
+use gr_bin::{git::git::LocalRepository, vcs::common::VersionControlSettings};
+use tracing::instrument;
+
+#[instrument(skip_all, fields(command = ?args.command))]
+pub fn get(args: Cli, conf: Configuration) -> Result<()> {
+    let Cli {
+        command,
+        branch,
+        dir,
+        auth,
+        output: _,
+        verbose: _,
+    } = args;
+    if let Commands::Pr(PrCommands::Get { .. }) = command {
+        let repository = LocalRepository::init(dir)?;
+        let (hostname, repo, ..) = repository.get_parsed_remote(branch)?;
+
+        // Find settings or use the auth command
+        let settings = conf.find_settings(&hostname, &repo);
+        let settings = if let Some(auth) = auth {
+            VersionControlSettings {
+                auth,
+                ..settings.unwrap_or_default()
+            }
+        } else {
+            settings.wrap_err(eyre!(
+                "Authentication not found for {} in {}.",
+                &hostname,
+                &repo
+            ))?
+        };
+
+        let _ = init_vcs(hostname, repo, settings);
+        
+        Err(eyre!("Getting information about current repo is not implemented"))
+    } else {
+        Err(eyre!("Invalid command!"))
+    }
+}

--- a/src/cmd/repo/mod.rs
+++ b/src/cmd/repo/mod.rs
@@ -1,0 +1,3 @@
+pub mod fork;
+pub mod get;
+pub mod new;

--- a/src/cmd/repo/mod.rs
+++ b/src/cmd/repo/mod.rs
@@ -1,3 +1,4 @@
+pub mod delete;
 pub mod fork;
 pub mod get;
 pub mod new;

--- a/src/cmd/repo/new.rs
+++ b/src/cmd/repo/new.rs
@@ -24,6 +24,10 @@ pub fn new(args: Cli, mut conf: Configuration) -> Result<()> {
         visibility,
         clone,
         open,
+        init,
+        default_branch,
+        gitignore,
+        license,
     }) = command
     {
         // Check if the host if full URL
@@ -69,6 +73,10 @@ pub fn new(args: Cli, mut conf: Configuration) -> Result<()> {
             organization,
             description,
             visibility: visibility.into(),
+            init,
+            default_branch,
+            gitignore,
+            license,
         })?;
 
         repo.print(open, output.into());

--- a/src/cmd/repo/new.rs
+++ b/src/cmd/repo/new.rs
@@ -63,7 +63,7 @@ pub fn new(args: Cli, mut conf: Configuration) -> Result<()> {
         let settings = VersionControlSettings {
             auth,
             vcs_type,
-            default_branch: None,
+            ..Default::default()
         };
 
         // Create the new repository

--- a/src/cmd/repo/new.rs
+++ b/src/cmd/repo/new.rs
@@ -1,15 +1,76 @@
 use crate::cmd::{
     args::{Cli, Commands, RepoCommands},
-    config::Configuration,
+    config::{Configuration, VcsConfig},
 };
-use eyre::{eyre, Result};
+use eyre::{eyre, ContextCompat, Result};
+use gr_bin::{
+    git::url::parse_url,
+    vcs::common::{init_vcs, CreateRepository, VersionControlSettings},
+};
 use tracing::instrument;
 
 #[instrument(skip_all, fields(command = ?args.command))]
-pub fn new(args: Cli, _: Configuration) -> Result<()> {
-    let Cli { command, .. } = args;
-    if let Commands::Repo(RepoCommands::New { .. }) = command {
-        Err(eyre!("Creating new repo is not implemented"))
+pub fn new(args: Cli, mut conf: Configuration) -> Result<()> {
+    let Cli {
+        command, output, ..
+    } = args;
+    if let Commands::Repo(RepoCommands::New {
+        repository,
+        host,
+        description,
+        visibility,
+    }) = command
+    {
+        // Check if the host if full URL
+        let (parsed_host, path) = parse_url(&repository)
+            .map(|(host, path)| (Some(host), path))
+            .unwrap_or((None, repository));
+
+        // Check if the path can be split into parts
+        let (organization, name) = match path.split_once('/') {
+            Some((organization, name)) => (Some(organization.to_string()), name.to_string()),
+            None => (None, path),
+        };
+
+        // Figure out the final hostname to use
+        let (hostname, VcsConfig { auth, vcs_type, .. }) = host
+            .clone()
+            .or(parsed_host)
+            .and_then(|host| conf.vcs.remove_entry(&host))
+            .or_else(|| {
+                // If only one VCS is used, fallback to that one
+                if conf.vcs.len() == 1 {
+                    conf.vcs.into_iter().next()
+                } else {
+                    None
+                }
+            })
+            .wrap_err(if let Some(host) = host {
+                eyre!("There is no host {host} in the configuration file.")
+            } else {
+                eyre!("You have to pass the server name (like github.com) in the --host flag.")
+            })?;
+
+        let settings = VersionControlSettings {
+            auth,
+            vcs_type,
+            default_branch: None,
+        };
+
+        // Create the new repository
+        let vcs = init_vcs(hostname, "".to_string(), settings)?;
+        let repo = vcs.create_repository(CreateRepository {
+            name,
+            organization,
+            description,
+            visibility: visibility.into(),
+        })?;
+
+        repo.print(false, output.into());
+
+        // TODO: clone it
+
+        Ok(())
     } else {
         Err(eyre!("Invalid command!"))
     }

--- a/src/cmd/repo/new.rs
+++ b/src/cmd/repo/new.rs
@@ -1,0 +1,16 @@
+use crate::cmd::{
+    args::{Cli, Commands, RepoCommands},
+    config::Configuration,
+};
+use eyre::{eyre, Result};
+use tracing::instrument;
+
+#[instrument(skip_all, fields(command = ?args.command))]
+pub fn new(args: Cli, _: Configuration) -> Result<()> {
+    let Cli { command, .. } = args;
+    if let Commands::Repo(RepoCommands::New { .. }) = command {
+        Err(eyre!("Creating new repo is not implemented"))
+    } else {
+        Err(eyre!("Invalid command!"))
+    }
+}

--- a/src/cmd/repo/new.rs
+++ b/src/cmd/repo/new.rs
@@ -23,6 +23,7 @@ pub fn new(args: Cli, mut conf: Configuration) -> Result<()> {
         description,
         visibility,
         clone,
+        open,
     }) = command
     {
         // Check if the host if full URL
@@ -70,7 +71,7 @@ pub fn new(args: Cli, mut conf: Configuration) -> Result<()> {
             visibility: visibility.into(),
         })?;
 
-        repo.print(false, output.into());
+        repo.print(open, output.into());
 
         let repository = LocalRepository::init(dir.clone())?;
         if clone {

--- a/src/formatters/formatter.rs
+++ b/src/formatters/formatter.rs
@@ -1,5 +1,5 @@
 use super::utils::to_fixed_length;
-use crate::vcs::common::{PullRequest, PullRequestState};
+use crate::vcs::common::{PullRequest, PullRequestState, Repository};
 use colored::Colorize;
 
 pub enum FormatterType {
@@ -78,5 +78,31 @@ impl Formatter for PullRequest {
         let branch = to_fixed_length(&self.source, SHORT_BRANCH_SIZE, true).blue();
         let colored_id = format!("#{}", self.id).dimmed();
         format!("{} {} {:>6}\n", title, branch, colored_id)
+    }
+}
+
+impl Formatter for Repository {
+    fn show_json(&self) -> String {
+        serde_json::to_string(&self).unwrap()
+    }
+    fn show_normal(&self) -> String {
+        let title_line = to_fixed_length(&self.full_name, TITLE_SIZE, true);
+        let description = if !self.description.is_empty() {
+            format!("\n{}\n---", self.description)
+        } else {
+            "".to_string()
+        };
+        let url_line = format!("{}", self.html_url.dimmed());
+
+        format!(
+            "{title_line}
+{description}
+{url_line}
+"
+        )
+    }
+    fn show_short(&self) -> String {
+        let title = to_fixed_length(&self.full_name, SHORT_TITLE_SIZE, true);
+        format!("{}\n", title)
     }
 }

--- a/src/formatters/formatter.rs
+++ b/src/formatters/formatter.rs
@@ -86,7 +86,12 @@ impl Formatter for Repository {
         serde_json::to_string(&self).unwrap()
     }
     fn show_normal(&self) -> String {
-        let title_line = to_fixed_length(&self.full_name, TITLE_SIZE, true);
+        let title_line = to_fixed_length(&self.full_name, TITLE_SIZE, true).bold();
+        let counts_line = format!(
+            "{} stars, {} forks",
+            self.stars_count.to_string().yellow(),
+            self.forks_count.to_string().yellow(),
+        );
         let description = if !self.description.is_empty() {
             format!("\n{}\n---", self.description)
         } else {
@@ -96,6 +101,7 @@ impl Formatter for Repository {
 
         format!(
             "{title_line}
+{counts_line}
 {description}
 {url_line}
 "

--- a/src/formatters/formatter.rs
+++ b/src/formatters/formatter.rs
@@ -87,6 +87,11 @@ impl Formatter for Repository {
     }
     fn show_normal(&self) -> String {
         let title_line = to_fixed_length(&self.full_name, TITLE_SIZE, true).bold();
+        let forked_line = if let Some(ref forked) = self.forked_from {
+            format!("{} {}\n", "forked from".dimmed(), forked.full_name)
+        } else {
+            String::new()
+        };
         let counts_line = format!(
             "{} stars, {} forks",
             self.stars_count.to_string().yellow(),
@@ -101,7 +106,7 @@ impl Formatter for Repository {
 
         format!(
             "{title_line}
-{counts_line}
+{forked_line}{counts_line}
 {description}
 {url_line}
 "

--- a/src/git/git.rs
+++ b/src/git/git.rs
@@ -2,7 +2,7 @@ use crate::git::url::parse_url;
 use eyre::{eyre, Context, ContextCompat, Result};
 use std::{
     env,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
 };
 use tracing::{debug, info, instrument};
@@ -59,17 +59,18 @@ impl LocalRepository {
     }
 
     #[instrument(skip(self))]
-    pub fn has_remote(self: &LocalRepository) -> bool {
-        if let Ok(remotes) = self.run(vec!["remote"], false) {
-            remotes.len() > 0
-        } else {
-            false
-        }
+    pub fn get_remotes(self: &LocalRepository) -> Result<Vec<String>> {
+        self.run(vec!["remote"], false)
     }
 
     #[instrument(skip(self))]
-    pub fn set_remote(self: &LocalRepository, url: String) -> Result<()> {
-        self.run(vec!["remote", "add", "origin", &url], false)?;
+    pub fn set_remote(self: &LocalRepository, name: String, url: String) -> Result<()> {
+        let existing_remotes = self.get_remotes()?;
+        if existing_remotes.iter().any(|s| s == &name) {
+            self.run(vec!["remote", "set-url", &name, &url], false)?;
+        } else {
+            self.run(vec!["remote", "add", &name, &url], false)?;
+        }
 
         Ok(())
     }
@@ -178,7 +179,7 @@ impl LocalRepository {
     }
 
     #[instrument(skip(self))]
-    pub fn push(self: &LocalRepository, branch: String) -> Result<()> {
+    pub fn push(self: &LocalRepository, branch: &str) -> Result<()> {
         self.run(vec!["push", "-u", "origin", &branch], true)
             .wrap_err(eyre!("Could not push {branch} to remote"))?;
 
@@ -188,8 +189,13 @@ impl LocalRepository {
     #[instrument(skip(self))]
     pub fn clone(self: &LocalRepository, url: String, dir: Option<String>) -> Result<()> {
         if let Some(dir) = dir {
-            // We have to reinitialize the repository to allow cloning into empty repo
-            LocalRepository::init(None)?.run(vec!["clone", &url, &dir], true)
+            if Path::new(&dir).exists() {
+                // If the path exists, we have to clone inside of it
+                self.run(vec!["clone", &url], true)
+            } else {
+                // Otherwise we have to reinitialize the repository to allow cloning into empty repo
+                LocalRepository::init(None)?.run(vec!["clone", &url, &dir], true)
+            }
         } else {
             self.run(vec!["clone", &url], true)
         }

--- a/src/git/git.rs
+++ b/src/git/git.rs
@@ -180,7 +180,7 @@ impl LocalRepository {
 
     #[instrument(skip(self))]
     pub fn push(self: &LocalRepository, branch: &str) -> Result<()> {
-        self.run(vec!["push", "-u", "origin", &branch], true)
+        self.run(vec!["push", "-u", "origin", branch], true)
             .wrap_err(eyre!("Could not push {branch} to remote"))?;
 
         Ok(())

--- a/src/git/git.rs
+++ b/src/git/git.rs
@@ -54,6 +54,27 @@ impl LocalRepository {
     }
 
     #[instrument(skip_all)]
+    pub fn has_git(self: &LocalRepository) -> bool {
+        self.run(vec!["rev-parse"], false).is_ok()
+    }
+
+    #[instrument(skip(self))]
+    pub fn has_remote(self: &LocalRepository) -> bool {
+        if let Ok(remotes) = self.run(vec!["remote"], false) {
+            remotes.len() > 0
+        } else {
+            false
+        }
+    }
+
+    #[instrument(skip(self))]
+    pub fn set_remote(self: &LocalRepository, url: String) -> Result<()> {
+        self.run(vec!["remote", "add", "origin", &url], false)?;
+
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
     pub fn get_branch(self: &LocalRepository) -> Result<String> {
         let head = self
             .run(vec!["rev-parse", "--abbrev-ref", "HEAD"], false)
@@ -84,7 +105,10 @@ impl LocalRepository {
                 vec!["config", &format!("branch.{branch_name}.remote")],
                 false,
             )
-            .wrap_err(eyre!("Branch {} doesn't have an upstream branch.", &branch_name))?
+            .wrap_err(eyre!(
+                "Branch {} doesn't have an upstream branch.",
+                &branch_name
+            ))?
             .into_iter()
             .next()
             .wrap_err(eyre!(
@@ -149,6 +173,27 @@ impl LocalRepository {
 
         debug!("Git pulling in {}.", &self.path);
         self.run(vec!["pull"], output)?;
+
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    pub fn push(self: &LocalRepository, branch: String) -> Result<()> {
+        self.run(vec!["push", "-u", "origin", &branch], true)
+            .wrap_err(eyre!("Could not push {branch} to remote"))?;
+
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    pub fn clone(self: &LocalRepository, url: String, dir: Option<String>) -> Result<()> {
+        if let Some(dir) = dir {
+            // We have to reinitialize the repository to allow cloning into empty repo
+            LocalRepository::init(None)?.run(vec!["clone", &url, &dir], true)
+        } else {
+            self.run(vec!["clone", &url], true)
+        }
+        .wrap_err(eyre!("Could not clone {url}."))?;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use cmd::{
         approve::approve, close::close, create::create, get::get as get_pr, list::list,
         merge::merge,
     },
-    repo::{fork::fork, get::get as get_repo, new::new},
+    repo::{fork::fork, get::get as get_repo, new::new, delete::delete},
 };
 use eyre::{eyre, Result};
 use std::process;
@@ -35,9 +35,10 @@ fn run(mut args: Cli) -> Result<()> {
         Commands::Repo(RepoCommands::Fork { .. }) => fork(args, conf),
         Commands::Repo(RepoCommands::Get { .. }) => get_repo(args, conf),
         Commands::Repo(RepoCommands::Open { .. }) => {
-            args.command = Commands::Repo(RepoCommands::Get { open: true });
+			args.command = Commands::Repo(RepoCommands::Get { open: true });
             get_repo(args, conf)
         }
+		Commands::Repo(RepoCommands::Delete { .. }) => delete(args, conf),
         Commands::Completion { .. } => Err(eyre!("Invalid command.")),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use cmd::{
         approve::approve, close::close, create::create, get::get as get_pr, list::list,
         merge::merge,
     },
-    repo::{fork::fork, get::get as get_repo, new::new, delete::delete},
+    repo::{delete::delete, fork::fork, get::get as get_repo, new::new},
 };
 use eyre::{eyre, Result};
 use std::process;
@@ -35,10 +35,10 @@ fn run(mut args: Cli) -> Result<()> {
         Commands::Repo(RepoCommands::Fork { .. }) => fork(args, conf),
         Commands::Repo(RepoCommands::Get { .. }) => get_repo(args, conf),
         Commands::Repo(RepoCommands::Open { .. }) => {
-			args.command = Commands::Repo(RepoCommands::Get { open: true });
+            args.command = Commands::Repo(RepoCommands::Get { open: true });
             get_repo(args, conf)
         }
-		Commands::Repo(RepoCommands::Delete { .. }) => delete(args, conf),
+        Commands::Repo(RepoCommands::Delete { .. }) => delete(args, conf),
         Commands::Completion { .. } => Err(eyre!("Invalid command.")),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,14 @@ mod cmd;
 mod utils;
 
 use cmd::{
-    args::{Cli, Commands, PrCommands},
+    args::{Cli, Commands, PrCommands, RepoCommands},
     config::Configuration,
     login::login::login,
-    pr::{approve::approve, close::close, create::create, get::get, list::list, merge::merge},
+    pr::{
+        approve::approve, close::close, create::create, get::get as get_pr, list::list,
+        merge::merge,
+    },
+    repo::{fork::fork, get::get as get_repo, new::new},
 };
 use eyre::{eyre, Result};
 use std::process;
@@ -18,15 +22,22 @@ fn run(mut args: Cli) -> Result<()> {
     match args.command {
         Commands::Login { .. } => login(args, conf),
         Commands::Pr(PrCommands::Create { .. }) => create(args, conf),
-        Commands::Pr(PrCommands::Get { .. }) => get(args, conf),
+        Commands::Pr(PrCommands::Get { .. }) => get_pr(args, conf),
         Commands::Pr(PrCommands::Open { .. }) => {
             args.command = Commands::Pr(PrCommands::Get { open: true });
-            get(args, conf)
+            get_pr(args, conf)
         }
         Commands::Pr(PrCommands::List { .. }) => list(args, conf),
         Commands::Pr(PrCommands::Approve { .. }) => approve(args, conf),
         Commands::Pr(PrCommands::Merge { .. }) => merge(args, conf),
         Commands::Pr(PrCommands::Close { .. }) => close(args, conf),
+        Commands::Repo(RepoCommands::New { .. }) => new(args, conf),
+        Commands::Repo(RepoCommands::Fork { .. }) => fork(args, conf),
+        Commands::Repo(RepoCommands::Get { .. }) => get_repo(args, conf),
+        Commands::Repo(RepoCommands::Open { .. }) => {
+            args.command = Commands::Repo(RepoCommands::Get { open: true });
+            get_repo(args, conf)
+        }
         Commands::Completion { .. } => Err(eyre!("Invalid command.")),
     }
 }

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -366,7 +366,7 @@ impl Bitbucket {
         match result {
             Ok(result) => {
                 let status = result.status();
-                let t = result.into_string()?;
+                let mut t = result.into_string()?;
 
                 info!(
                     "Received response with response code {} with body size {}.",
@@ -374,6 +374,12 @@ impl Bitbucket {
                     t.len()
                 );
                 trace!("Response body: {t}.");
+                
+				// Somewhat hacky, if the response is empty, return null
+                if t.is_empty() {
+                    t = "null".to_string();
+                }
+
                 let t: T = serde_json::from_str(&t)?;
                 Ok(t)
             }
@@ -584,5 +590,12 @@ impl VersionControl for Bitbucket {
         )?;
 
         Ok(new_repo.into())
+    }
+
+    #[instrument(skip_all)]
+    fn delete_repository(&self) -> Result<()> {
+        let _: () = self.call("DELETE", &self.get_repository_url(""), None as Option<i32>)?;
+
+        Ok(())
     }
 }

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -69,6 +69,12 @@ impl From<BitbucketUser> for User {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct BitbucketCloneLink {
+    pub name: String,
+    pub href: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct BitbucketLink {
     pub href: String,
 }
@@ -76,6 +82,7 @@ pub struct BitbucketLink {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BitbucketLinks {
     pub html: BitbucketLink,
+    pub clone: Vec<BitbucketCloneLink>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -142,6 +149,16 @@ impl From<BitbucketRepository> for Repository {
             is_private,
             ..
         } = repo;
+        let ssh_url = links
+            .clone
+            .iter()
+            .find(|BitbucketCloneLink { name, .. }| name == "ssh")
+            .map(|BitbucketCloneLink { href, .. }| href);
+        let https_url = links
+            .clone
+            .iter()
+            .find(|BitbucketCloneLink { name, .. }| name == "https")
+            .map(|BitbucketCloneLink { href, .. }| href);
         Repository {
             name,
             full_name,
@@ -159,6 +176,8 @@ impl From<BitbucketRepository> for Repository {
             default_branch: mainbranch.name,
             forks_count: 0,
             stars_count: 0,
+            ssh_url: ssh_url.unwrap().to_owned(),
+            https_url: https_url.unwrap().to_owned(),
         }
     }
 }

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -565,11 +565,7 @@ impl VersionControl for Bitbucket {
 
     #[instrument(skip_all)]
     fn fork_repository(&self, repo: ForkRepository) -> Result<Repository> {
-        let ForkRepository {
-            original,
-            name,
-            organization,
-        } = repo;
+        let ForkRepository { name, organization } = repo;
 
         let (user, _) = self
             .settings
@@ -580,7 +576,7 @@ impl VersionControl for Bitbucket {
 
         let new_repo: BitbucketRepository = self.call(
             "POST",
-            &format!("/repos/{original}/forks"),
+            &self.get_repository_url("/forks"),
             Some(BitbucketForkRepository {
                 name,
                 workspace: BitbucketForkRepositoryWorkspace { slug: workspace },

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -374,8 +374,8 @@ impl Bitbucket {
                     t.len()
                 );
                 trace!("Response body: {t}.");
-                
-				// Somewhat hacky, if the response is empty, return null
+
+                // Somewhat hacky, if the response is empty, return null
                 if t.is_empty() {
                     t = "null".to_string();
                 }
@@ -594,7 +594,7 @@ impl VersionControl for Bitbucket {
 
     #[instrument(skip_all)]
     fn delete_repository(&self) -> Result<()> {
-        let _: () = self.call("DELETE", &self.get_repository_url(""), None as Option<i32>)?;
+        self.call("DELETE", &self.get_repository_url(""), None as Option<i32>)?;
 
         Ok(())
     }

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -35,6 +35,37 @@ impl From<BitbucketPullRequestState> for PullRequestState {
     }
 }
 
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct BitbucketUser {
+    pub uuid: String,
+    pub nickname: String,
+    pub display_name: String,
+}
+
+impl From<BitbucketUser> for User {
+    fn from(user: BitbucketUser) -> User {
+        let BitbucketUser { uuid, nickname, .. } = user;
+        User {
+            id: uuid,
+            username: nickname,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct BitbucketTeam {
+    pub uuid: String,
+    pub username: String,
+    pub display_name: String,
+}
+
+impl From<BitbucketTeam> for User {
+    fn from(user: BitbucketTeam) -> User {
+        let BitbucketTeam { uuid, username, .. } = user;
+        User { id: uuid, username }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BitbucketApproval {
     approved: bool,
@@ -44,20 +75,6 @@ pub struct BitbucketApproval {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BitbucketMembership {
     user: BitbucketUser,
-}
-
-#[derive(Debug, Default, Deserialize, Serialize)]
-pub struct BitbucketUser {
-    pub uuid: String,
-    pub username: String,
-    pub display_name: String,
-}
-
-impl From<BitbucketUser> for User {
-    fn from(user: BitbucketUser) -> User {
-        let BitbucketUser { uuid, username, .. } = user;
-        User { id: uuid, username }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -72,9 +89,14 @@ pub struct BitbucketLink {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct BitbucketLinks {
+pub struct BitbucketRepositoryLinks {
     pub html: BitbucketLink,
     pub clone: Vec<BitbucketCloneLink>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BitbucketPullRequestLinks {
+    pub html: BitbucketLink,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -106,8 +128,8 @@ pub struct BitbucketRepository {
     uuid: String,
     name: String,
     full_name: String,
-    links: BitbucketLinks,
-    owner: BitbucketUser,
+    links: BitbucketRepositoryLinks,
+    owner: BitbucketTeam,
     description: String,
     #[serde(with = "time::serde::iso8601")]
     created_on: OffsetDateTime,
@@ -193,7 +215,7 @@ pub struct BitbucketPullRequest {
     pub state: BitbucketPullRequestState,
     pub title: String,
     pub description: String,
-    pub links: BitbucketLinks,
+    pub links: BitbucketPullRequestLinks,
     #[serde(with = "time::serde::iso8601")]
     pub created_on: OffsetDateTime,
     #[serde(with = "time::serde::iso8601")]
@@ -405,7 +427,7 @@ impl Bitbucket {
         Ok(members
             .into_iter()
             .map(|m| m.user)
-            .filter(|u| usernames.contains(&u.username))
+            .filter(|u| usernames.contains(&u.nickname))
             .collect())
     }
 }

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -509,10 +509,9 @@ impl VersionControl for Bitbucket {
         let reviewers = self.get_workspace_users(pr.reviewers.clone())?;
         pr.reviewers = reviewers.into_iter().map(|r| r.uuid).collect();
 
-        let is_fork = pr.fork;
         let mut url = self.get_repository_url("/pullrequests");
         let mut bitbucket_pr = BitbucketCreatePullRequest::from(pr);
-        if is_fork {
+        if self.settings.fork {
             let repo = self.get_repository()?;
             if let Some(forked) = repo.forked_from {
                 url = format!("/repositories/{}/pullrequests", forked.full_name);

--- a/src/vcs/bitbucket.rs
+++ b/src/vcs/bitbucket.rs
@@ -169,7 +169,8 @@ impl From<BitbucketRepository> for Repository {
 #[derive(Debug, Deserialize, Serialize)]
 struct BitbucketCreateRepository {
     name: String,
-    description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
     is_private: bool,
 }
 
@@ -527,6 +528,7 @@ impl VersionControl for Bitbucket {
             organization,
             visibility,
             description,
+            ..
         } = repo;
         let (user, _) = self
             .settings
@@ -536,7 +538,7 @@ impl VersionControl for Bitbucket {
         let workspace = organization.unwrap_or(user.to_string());
         let create_repo: BitbucketCreateRepository = BitbucketCreateRepository {
             name: name.clone(),
-            description: description.unwrap_or_default(),
+            description,
             is_private: visibility != RepositoryVisibility::Public,
         };
         let new_repo: BitbucketRepository = self.call(

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -56,7 +56,6 @@ pub struct CreatePullRequest {
     pub target: Option<String>,
     pub close_source_branch: bool,
     pub reviewers: Vec<String>,
-    pub fork: bool,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -150,6 +149,7 @@ pub struct VersionControlSettings {
     pub auth: String,
     pub vcs_type: Option<String>,
     pub default_branch: Option<String>,
+    pub fork: bool,
 }
 pub trait VersionControl {
     fn init(hostname: String, repo: String, settings: VersionControlSettings) -> Self

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -164,6 +164,7 @@ pub trait VersionControl {
     fn get_repository(&self) -> Result<Repository>;
     fn create_repository(&self, repo: CreateRepository) -> Result<Repository>;
     fn fork_repository(&self, repo: ForkRepository) -> Result<Repository>;
+	fn delete_repository(&self) -> Result<()>;
 }
 
 pub fn init_vcs(

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -56,6 +56,7 @@ pub struct CreatePullRequest {
     pub target: Option<String>,
     pub close_source_branch: bool,
     pub reviewers: Vec<String>,
+    pub fork: bool,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -129,7 +129,7 @@ pub struct CreateRepository {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ForkRepository {
     pub original: String,
-    pub name: String,
+    pub name: Option<String>,
     pub organization: Option<String>,
 }
 

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -94,6 +94,8 @@ pub struct Repository {
     pub full_name: String,
     pub owner: Option<User>,
     pub html_url: String,
+    pub ssh_url: String,
+    pub https_url: String,
     pub description: String,
     #[serde(with = "time::serde::iso8601")]
     pub created_at: OffsetDateTime,

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -124,6 +124,10 @@ pub struct CreateRepository {
     pub organization: Option<String>,
     pub description: Option<String>,
     pub visibility: RepositoryVisibility,
+	pub init: bool,
+	pub default_branch: Option<String>,
+	pub gitignore: Option<String>,
+	pub license: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -128,7 +128,6 @@ pub struct CreateRepository {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ForkRepository {
-    pub original: String,
     pub name: Option<String>,
     pub organization: Option<String>,
 }

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -89,6 +89,13 @@ pub enum RepositoryVisibility {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct ForkedFromRepository {
+    pub name: String,
+    pub full_name: String,
+    pub html_url: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Repository {
     pub name: String,
     pub full_name: String,
@@ -106,6 +113,7 @@ pub struct Repository {
     pub default_branch: String,
     pub forks_count: u32,
     pub stars_count: u32,
+    pub forked_from: Option<ForkedFromRepository>,
 }
 
 impl Repository {
@@ -124,10 +132,10 @@ pub struct CreateRepository {
     pub organization: Option<String>,
     pub description: Option<String>,
     pub visibility: RepositoryVisibility,
-	pub init: bool,
-	pub default_branch: Option<String>,
-	pub gitignore: Option<String>,
-	pub license: Option<String>,
+    pub init: bool,
+    pub default_branch: Option<String>,
+    pub gitignore: Option<String>,
+    pub license: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -164,7 +172,7 @@ pub trait VersionControl {
     fn get_repository(&self) -> Result<Repository>;
     fn create_repository(&self, repo: CreateRepository) -> Result<Repository>;
     fn fork_repository(&self, repo: ForkRepository) -> Result<Repository>;
-	fn delete_repository(&self) -> Result<()>;
+    fn delete_repository(&self) -> Result<()>;
 }
 
 pub fn init_vcs(

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -81,6 +81,13 @@ pub struct ListPullRequestFilters {
     pub state: PullRequestStateFilter,
 }
 
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub enum RepositoryVisibility {
+    Public,
+    Internal,
+    Private,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Repository {
     pub name: String,
@@ -92,7 +99,7 @@ pub struct Repository {
     pub created_at: OffsetDateTime,
     #[serde(with = "time::serde::iso8601")]
     pub updated_at: OffsetDateTime,
-    pub private: bool,
+    pub visibility: RepositoryVisibility,
     pub archived: bool,
     pub default_branch: String,
     pub forks_count: u32,
@@ -107,6 +114,21 @@ impl Repository {
         }
         print!("{}", self.show(formatter_type));
     }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CreateRepository {
+    pub name: String,
+    pub organization: Option<String>,
+    pub description: Option<String>,
+    pub visibility: RepositoryVisibility,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ForkRepository {
+    pub original: String,
+    pub name: String,
+    pub organization: Option<String>,
 }
 
 #[derive(Debug, Default)]
@@ -135,6 +157,8 @@ pub trait VersionControl {
 
     // Repositories
     fn get_repository(&self) -> Result<Repository>;
+    fn create_repository(&self, repo: CreateRepository) -> Result<Repository>;
+    fn fork_repository(&self, repo: ForkRepository) -> Result<Repository>;
 }
 
 pub fn init_vcs(

--- a/src/vcs/gitea.rs
+++ b/src/vcs/gitea.rs
@@ -42,6 +42,8 @@ struct GiteaRepository {
     private: bool,
     owner: GiteaUser,
     html_url: String,
+    ssh_url: String,
+    clone_url: String,
     description: Option<String>,
     #[serde(with = "time::serde::iso8601")]
     created_at: OffsetDateTime,
@@ -61,6 +63,8 @@ impl From<GiteaRepository> for Repository {
             private,
             owner,
             html_url,
+            ssh_url,
+            clone_url,
             description,
             created_at,
             updated_at,
@@ -79,6 +83,8 @@ impl From<GiteaRepository> for Repository {
                 RepositoryVisibility::Public
             },
             html_url,
+            ssh_url,
+            https_url: clone_url,
             description: description.unwrap_or_default(),
             created_at,
             updated_at,

--- a/src/vcs/gitea.rs
+++ b/src/vcs/gitea.rs
@@ -2,7 +2,7 @@
 use super::common::{
     CreatePullRequest, CreateRepository, ForkRepository, ListPullRequestFilters, PullRequest,
     PullRequestState, PullRequestStateFilter, Repository, RepositoryVisibility, User,
-    VersionControl, VersionControlSettings,
+    VersionControl, VersionControlSettings, ForkedFromRepository,
 };
 use eyre::{eyre, ContextCompat, Result};
 use native_tls::TlsConnector;
@@ -53,6 +53,8 @@ struct GiteaRepository {
     default_branch: String,
     stars_count: u32,
     forks_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent: Option<Box<GiteaRepository>>,
 }
 
 impl From<GiteaRepository> for Repository {
@@ -72,6 +74,7 @@ impl From<GiteaRepository> for Repository {
             default_branch,
             stars_count,
             forks_count,
+            parent
         } = repo;
         Repository {
             name,
@@ -92,6 +95,23 @@ impl From<GiteaRepository> for Repository {
             default_branch,
             stars_count,
             forks_count,
+            forked_from: parent.map(|r| ForkedFromRepository::from(*r)),
+        }
+    }
+}
+
+impl From<GiteaRepository> for ForkedFromRepository {
+    fn from(repo: GiteaRepository) -> ForkedFromRepository {
+        let GiteaRepository {
+            name,
+            full_name,
+            html_url,
+            ..
+        } = repo;
+        ForkedFromRepository {
+            name,
+            full_name,
+            html_url,
         }
     }
 }

--- a/src/vcs/gitea.rs
+++ b/src/vcs/gitea.rs
@@ -564,7 +564,7 @@ impl VersionControl for Gitea {
 
     #[instrument(skip_all)]
     fn delete_repository(&self) -> Result<()> {
-        let _: () = self.call("DELETE", &self.get_repository_url(""), None as Option<i32>)?;
+        self.call("DELETE", &self.get_repository_url(""), None as Option<i32>)?;
 
         Ok(())
     }

--- a/src/vcs/gitea.rs
+++ b/src/vcs/gitea.rs
@@ -435,10 +435,9 @@ impl VersionControl for Gitea {
             pr.target = Some(default_branch);
         }
 
-        let is_fork = pr.fork;
         let mut url = self.get_repository_url("/pulls");
         let mut gitea_pr = GiteaCreatePullRequest::from(pr);
-        if is_fork {
+        if self.settings.fork {
             let repo = self.get_repository()?;
             if let Some(forked) = repo.forked_from {
                 url = format!("/repos/{}/pulls", forked.full_name);

--- a/src/vcs/gitea.rs
+++ b/src/vcs/gitea.rs
@@ -104,6 +104,14 @@ struct GiteaCreateRepository {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+struct GiteaForkRepository {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    organization: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub enum GiteaPullRequestState {
     #[serde(rename = "open")]
     Open,
@@ -526,7 +534,19 @@ impl VersionControl for Gitea {
     }
 
     #[instrument(skip_all)]
-    fn fork_repository(&self, _: ForkRepository) -> Result<Repository> {
-        todo!()
+    fn fork_repository(&self, repo: ForkRepository) -> Result<Repository> {
+        let ForkRepository {
+            original,
+            name,
+            organization,
+        } = repo;
+
+        let new_repo: GiteaRepository = self.call(
+            "POST",
+            &format!("/repos/{original}/forks"),
+            Some(GiteaForkRepository { organization, name }),
+        )?;
+
+        Ok(new_repo.into())
     }
 }

--- a/src/vcs/gitea.rs
+++ b/src/vcs/gitea.rs
@@ -96,11 +96,19 @@ impl From<GiteaRepository> for Repository {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 struct GiteaCreateRepository {
     name: String,
-    description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
     private: bool,
+    auto_init: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    license: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gitignores: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -518,11 +526,19 @@ impl VersionControl for Gitea {
             description,
             visibility,
             organization,
+            init,
+            default_branch,
+            gitignore,
+            license,
         } = repo;
         let create_repo: GiteaCreateRepository = GiteaCreateRepository {
             name,
-            description: description.unwrap_or_default(),
+            description,
             private: visibility != RepositoryVisibility::Public,
+            auto_init: init,
+            default_branch,
+            gitignores: gitignore,
+            license,
         };
         let new_repo: GiteaRepository = if let Some(org) = organization {
             self.call("POST", &format!("/orgs/{org}/repos"), Some(create_repo))

--- a/src/vcs/gitea.rs
+++ b/src/vcs/gitea.rs
@@ -561,4 +561,11 @@ impl VersionControl for Gitea {
 
         Ok(new_repo.into())
     }
+
+    #[instrument(skip_all)]
+    fn delete_repository(&self) -> Result<()> {
+        let _: () = self.call("DELETE", &self.get_repository_url(""), None as Option<i32>)?;
+
+        Ok(())
+    }
 }

--- a/src/vcs/gitea.rs
+++ b/src/vcs/gitea.rs
@@ -535,15 +535,11 @@ impl VersionControl for Gitea {
 
     #[instrument(skip_all)]
     fn fork_repository(&self, repo: ForkRepository) -> Result<Repository> {
-        let ForkRepository {
-            original,
-            name,
-            organization,
-        } = repo;
+        let ForkRepository { name, organization } = repo;
 
         let new_repo: GiteaRepository = self.call(
             "POST",
-            &format!("/repos/{original}/forks"),
+            &self.get_repository_url("/forks"),
             Some(GiteaForkRepository { organization, name }),
         )?;
 

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -394,10 +394,9 @@ impl VersionControl for GitHub {
             pr.target = Some(default_branch);
         }
 
-        let is_fork = pr.fork;
         let mut url = self.get_repository_url("/pulls");
         let mut github_pr = GitHubCreatePullRequest::from(pr);
-        if is_fork {
+        if self.settings.fork {
             let repo = self.get_repository()?;
             if let Some(forked) = repo.forked_from {
                 url = format!("/repos/{}/pulls", forked.full_name);

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -525,7 +525,7 @@ impl VersionControl for GitHub {
 
     #[instrument(skip_all)]
     fn delete_repository(&self) -> Result<()> {
-        let _: () = self.call("DELETE", &self.get_repository_url(""), None as Option<i32>)?;
+        self.call("DELETE", &self.get_repository_url(""), None as Option<i32>)?;
 
         Ok(())
     }

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -297,7 +297,7 @@ impl GitHub {
         match result {
             Ok(result) => {
                 let status = result.status();
-                let t = result.into_string()?;
+                let mut t = result.into_string()?;
 
                 info!(
                     "Received response with response code {} with body size {}.",
@@ -305,6 +305,12 @@ impl GitHub {
                     t.len()
                 );
                 trace!("Response body: {t}.");
+
+                // Somewhat hacky, if the response is empty, return null
+                if t.is_empty() {
+                    t = "null".to_string();
+                }
+
                 let t: T = serde_json::from_str(&t)?;
                 Ok(t)
             }
@@ -515,5 +521,12 @@ impl VersionControl for GitHub {
         )?;
 
         Ok(new_repo.into())
+    }
+
+    #[instrument(skip_all)]
+    fn delete_repository(&self) -> Result<()> {
+        let _: () = self.call("DELETE", &self.get_repository_url(""), None as Option<i32>)?;
+
+        Ok(())
     }
 }

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -493,15 +493,11 @@ impl VersionControl for GitHub {
 
     #[instrument(skip_all)]
     fn fork_repository(&self, repo: ForkRepository) -> Result<Repository> {
-        let ForkRepository {
-            original,
-            name,
-            organization,
-        } = repo;
+        let ForkRepository { name, organization } = repo;
 
         let new_repo: GitHubRepository = self.call(
             "POST",
-            &format!("/repos/{original}/forks"),
+            &self.get_repository_url("/forks"),
             Some(GitHubForkRepository { organization, name }),
         )?;
 

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -1,8 +1,8 @@
 // Documentation: https://docs.github.com/en/rest/quickstart
 use super::common::{
-    CreatePullRequest, CreateRepository, ForkRepository, ListPullRequestFilters, PullRequest,
-    PullRequestState, PullRequestStateFilter, Repository, RepositoryVisibility, User,
-    VersionControl, VersionControlSettings,
+    CreatePullRequest, CreateRepository, ForkRepository, ForkedFromRepository,
+    ListPullRequestFilters, PullRequest, PullRequestState, PullRequestStateFilter, Repository,
+    RepositoryVisibility, User, VersionControl, VersionControlSettings,
 };
 use eyre::{eyre, ContextCompat, Result};
 use native_tls::TlsConnector;
@@ -46,6 +46,8 @@ struct GitHubRepository {
     forks_count: u32,
     archived: bool,
     default_branch: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent: Option<Box<GitHubRepository>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -86,6 +88,7 @@ impl From<GitHubRepository> for Repository {
             forks_count,
             archived,
             default_branch,
+            parent,
         } = repo;
         Repository {
             name,
@@ -106,6 +109,23 @@ impl From<GitHubRepository> for Repository {
             default_branch,
             stars_count: stargazers_count,
             forks_count,
+            forked_from: parent.map(|r| ForkedFromRepository::from(*r)),
+        }
+    }
+}
+
+impl From<GitHubRepository> for ForkedFromRepository {
+    fn from(repo: GitHubRepository) -> ForkedFromRepository {
+        let GitHubRepository {
+            name,
+            full_name,
+            html_url,
+            ..
+        } = repo;
+        ForkedFromRepository {
+            name,
+            full_name,
+            html_url,
         }
     }
 }

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -35,6 +35,8 @@ struct GitHubRepository {
     private: bool,
     owner: GitHubUser,
     html_url: String,
+    ssh_url: String,
+    clone_url: String,
     description: Option<String>,
     #[serde(with = "time::serde::iso8601")]
     created_at: OffsetDateTime,
@@ -61,6 +63,8 @@ impl From<GitHubRepository> for Repository {
             private,
             owner,
             html_url,
+            ssh_url,
+            clone_url,
             description,
             created_at,
             updated_at,
@@ -79,6 +83,8 @@ impl From<GitHubRepository> for Repository {
                 RepositoryVisibility::Public
             },
             html_url,
+            ssh_url,
+            https_url: clone_url,
             description: description.unwrap_or_default(),
             created_at,
             updated_at,

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -55,6 +55,14 @@ struct GitHubCreateRepository {
     private: bool,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct GitHubForkRepository {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    organization: Option<String>,
+}
+
 impl From<GitHubRepository> for Repository {
     fn from(repo: GitHubRepository) -> Repository {
         let GitHubRepository {
@@ -484,7 +492,19 @@ impl VersionControl for GitHub {
     }
 
     #[instrument(skip_all)]
-    fn fork_repository(&self, _: ForkRepository) -> Result<Repository> {
-        todo!()
+    fn fork_repository(&self, repo: ForkRepository) -> Result<Repository> {
+        let ForkRepository {
+            original,
+            name,
+            organization,
+        } = repo;
+
+        let new_repo: GitHubRepository = self.call(
+            "POST",
+            &format!("/repos/{original}/forks"),
+            Some(GitHubForkRepository { organization, name }),
+        )?;
+
+        Ok(new_repo.into())
     }
 }

--- a/src/vcs/gitlab.rs
+++ b/src/vcs/gitlab.rs
@@ -568,7 +568,7 @@ impl VersionControl for GitLab {
         } = repo;
         let path = match (&namespace_path, &name) {
             (Some(ns), Some(n)) => Some(format!("{ns}/{n}")),
-			(None, Some(n)) => Some(format!("{n}")),
+			(None, Some(n)) => Some(n.to_string()),
             _ => None,
         };
 

--- a/src/vcs/gitlab.rs
+++ b/src/vcs/gitlab.rs
@@ -544,7 +544,7 @@ impl VersionControl for GitLab {
 
         let new_repo: GitLabRepository = self.call(
             "POST",
-            &self.get_repository_url("/forks"),
+            &self.get_repository_url("/fork"),
             Some(GitLabForkRepository {
                 name,
                 namespace_path,

--- a/src/vcs/gitlab.rs
+++ b/src/vcs/gitlab.rs
@@ -132,7 +132,7 @@ impl From<GitLabRepository> for Repository {
             stars_count: star_count,
             ssh_url: ssh_url_to_repo,
             https_url: http_url_to_repo,
-            forked_from: forked_from_project.map(|r| ForkedFromRepository::from(r)),
+            forked_from: forked_from_project.map(ForkedFromRepository::from),
         }
     }
 }

--- a/src/vcs/gitlab.rs
+++ b/src/vcs/gitlab.rs
@@ -72,6 +72,8 @@ struct GitLabRepository {
     last_activity_at: OffsetDateTime,
     default_branch: String,
     web_url: String,
+    ssh_url_to_repo: String,
+    http_url_to_repo: String,
     forks_count: u32,
     star_count: u32,
     archived: bool,
@@ -88,6 +90,8 @@ impl From<GitLabRepository> for Repository {
             created_at,
             default_branch,
             web_url,
+            ssh_url_to_repo,
+            http_url_to_repo,
             forks_count,
             star_count,
             last_activity_at,
@@ -113,6 +117,8 @@ impl From<GitLabRepository> for Repository {
             default_branch,
             forks_count,
             stars_count: star_count,
+            ssh_url: ssh_url_to_repo,
+            https_url: http_url_to_repo,
         }
     }
 }
@@ -497,9 +503,13 @@ impl VersionControl for GitLab {
     #[instrument(skip_all)]
     fn create_repository(&self, repo: CreateRepository) -> Result<Repository> {
         let namespace_id = repo.organization.and_then(|org| {
-            self.call::<GitLabNamespace, Option<u32>>("POST", &format!("/namespaces?search={org}"), None)
-                .map(|ns| ns.id)
-                .ok()
+            self.call::<GitLabNamespace, Option<u32>>(
+                "POST",
+                &format!("/namespaces?search={org}"),
+                None,
+            )
+            .map(|ns| ns.id)
+            .ok()
         });
         let create_repo = GitLabCreateRepository {
             name: repo.name.clone(),

--- a/src/vcs/gitlab.rs
+++ b/src/vcs/gitlab.rs
@@ -538,14 +538,13 @@ impl VersionControl for GitLab {
     #[instrument(skip_all)]
     fn fork_repository(&self, repo: ForkRepository) -> Result<Repository> {
         let ForkRepository {
-            original,
             name,
             organization: namespace_path,
         } = repo;
 
         let new_repo: GitLabRepository = self.call(
             "POST",
-            &format!("/repos/{}/forks", encode(&original)),
+            &self.get_repository_url("/forks"),
             Some(GitLabForkRepository {
                 name,
                 namespace_path,

--- a/src/vcs/gitlab.rs
+++ b/src/vcs/gitlab.rs
@@ -278,7 +278,6 @@ impl From<CreatePullRequest> for GitLabCreatePullRequest {
             target,
             close_source_branch,
             reviewers,
-            fork: _,
         } = pr;
         Self {
             title,
@@ -459,9 +458,8 @@ impl VersionControl for GitLab {
             pr.target = Some(default_branch);
         }
 
-        let is_fork = pr.fork;
         let mut gitlab_pr = GitLabCreatePullRequest::from(pr);
-        if is_fork {
+        if self.settings.fork {
             let repo = self.get_repository_data()?;
             if let Some(forked) = repo.forked_from_project {
                 gitlab_pr.target_project_id = Some(forked.id);

--- a/tests/pr-bitbucket.rs
+++ b/tests/pr-bitbucket.rs
@@ -93,9 +93,9 @@ fn test_pr() -> Result<()> {
     let no_pr = exec(gr, vec!["pr", "get"], false);
     assert!(no_pr.is_err());
     if let Err(err) = no_pr {
-        assert!(err.to_string().contains(&format!(
-            "Pull request on branch {pr_branch} not found."
-        )));
+        assert!(err
+            .to_string()
+            .contains(&format!("Pull request on branch {pr_branch} not found.")));
     }
 
     // Create the PR

--- a/tests/pr-gitea.rs
+++ b/tests/pr-gitea.rs
@@ -93,9 +93,9 @@ fn test_pr() -> Result<()> {
     let no_pr = exec(gr, vec!["pr", "get"], false);
     assert!(no_pr.is_err());
     if let Err(err) = no_pr {
-        assert!(err.to_string().contains(&format!(
-            "Pull request on branch {pr_branch} not found."
-        )));
+        assert!(err
+            .to_string()
+            .contains(&format!("Pull request on branch {pr_branch} not found.")));
     }
 
     // Create the PR

--- a/tests/pr-gitea.rs
+++ b/tests/pr-gitea.rs
@@ -130,7 +130,7 @@ fn test_pr() -> Result<()> {
     let merged_pr = exec(gr, vec!["pr", "merge"], false)?;
     test_pr_result(merged_pr, &key)?;
     let current_branch = exec("git", vec!["branch", "--show-current"], false)?;
-    assert_eq!(current_branch.iter().next().unwrap().trim(), &base_branch);
+    assert_eq!(current_branch.first().unwrap().trim(), &base_branch);
 
     // Delete created repositories
     env::set_current_dir("..")?;

--- a/tests/pr-github.rs
+++ b/tests/pr-github.rs
@@ -93,9 +93,9 @@ fn test_pr() -> Result<()> {
     let no_pr = exec(gr, vec!["pr", "get"], false);
     assert!(no_pr.is_err());
     if let Err(err) = no_pr {
-        assert!(err.to_string().contains(&format!(
-            "Pull request on branch {pr_branch} not found."
-        )));
+        assert!(err
+            .to_string()
+            .contains(&format!("Pull request on branch {pr_branch} not found.")));
     }
 
     // Create the PR

--- a/tests/pr-gitlab.rs
+++ b/tests/pr-gitlab.rs
@@ -94,9 +94,9 @@ fn test_pr() -> Result<()> {
     let no_pr = exec(gr, vec!["pr", "get"], false);
     assert!(no_pr.is_err());
     if let Err(err) = no_pr {
-        assert!(err.to_string().contains(&format!(
-            "Pull request on branch {pr_branch} not found."
-        )));
+        assert!(err
+            .to_string()
+            .contains(&format!("Pull request on branch {pr_branch} not found.")));
     }
 
     // Create the PR

--- a/tests/repo-bitbucket.rs
+++ b/tests/repo-bitbucket.rs
@@ -1,0 +1,146 @@
+use eyre::{eyre, Result};
+use rand::{distributions::Alphanumeric, Rng};
+use std::process::{Command, Stdio};
+use std::{env, fs};
+
+fn str_rnd(count: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(count)
+        .map(char::from)
+        .collect()
+}
+
+fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
+    let command = Command::new(cmd)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(if inherit {
+            Stdio::inherit()
+        } else {
+            Stdio::piped()
+        })
+        .stderr(if inherit {
+            Stdio::inherit()
+        } else {
+            Stdio::piped()
+        })
+        .output()?;
+
+    if command.status.success() {
+        let output = String::from_utf8_lossy(&command.stdout).to_string();
+        Ok(output
+            .lines()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>())
+    } else {
+        Err(eyre!(
+            "{} {:?} {} {}",
+            cmd,
+            args,
+            String::from_utf8_lossy(&command.stdout).to_string(),
+            String::from_utf8_lossy(&command.stderr).to_string()
+        ))
+    }
+}
+
+fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
+    dbg!(&repo);
+
+    let mut repo_lines = repo.iter();
+    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
+    repo_lines.next();
+    assert!(repo_lines.next().unwrap().contains(&key));
+
+    Ok(())
+}
+
+fn test_repo() -> Result<()> {
+    let key = str_rnd(12).to_ascii_lowercase();
+
+    let forked_url = env::var("GR_BITBUCKET_FORKED_REPOSITORY_URL")
+        .unwrap_or("git@bitbucket.org:grbin-test2/gr-bin-forked.git".to_string());
+    // On Bitbucket you can only fork into an org, not to a user
+    let fork_into = env::var("GR_BITBUCKET_FORK_INTO").unwrap_or("grbin-test".to_string());
+
+    let base_dir = env::current_dir()?;
+    let repositories_dir = base_dir.join("tests").join("repositories");
+    let gr_path = base_dir.join("target/debug/gr");
+    let gr = gr_path.to_str().unwrap();
+
+    // Create new repo and clone it
+    let first_repo = format!("{key}-1");
+    env::set_current_dir(repositories_dir)?;
+    let repo = exec(
+        gr,
+        vec![
+            "repo",
+            "new",
+            &format!("grbin-test/{first_repo}"),
+            "--clone",
+            "--host=bitbucket.org",
+        ],
+        false,
+    )?;
+    test_repo_result(repo, &first_repo)?;
+    env::set_current_dir(&first_repo)?;
+
+    // Create a commit because Bitbucket can't
+    fs::write("README.md", "")?;
+    exec("git", vec!["add", "-A"], false)?;
+    exec("git", vec!["commit", "-m", "README"], false)?;
+
+    // Test if the repo exists
+    let repo = exec(gr, vec!["repo", "get"], false)?;
+    test_repo_result(repo, &first_repo)?;
+
+    // Delete the repo, and test if it is actually deleted
+    exec(
+        gr,
+        vec!["repo", "delete", "--yes-delete-permanently"],
+        false,
+    )?;
+    let no_repo = exec(gr, vec!["repo", "get"], false);
+    assert!(no_repo.is_err());
+
+    // Fork repo and clone it
+    let second_repo = format!("{key}-2");
+    env::set_current_dir("..")?;
+    let repo = exec(
+        gr,
+        vec!["repo", "fork", &forked_url, &format!("{fork_into}/{second_repo}"), "--clone"],
+        false,
+    )?;
+    test_repo_result(repo, &second_repo)?;
+    env::set_current_dir(&second_repo)?;
+
+    // Test if the forked repo exists
+    let repo = exec(gr, vec!["repo", "get"], false)?;
+    test_repo_result(repo, &second_repo)?;
+
+    // Delete the repo, and test if it is actually deleted
+    exec(
+        gr,
+        vec!["repo", "delete", "--yes-delete-permanently"],
+        false,
+    )?;
+    let no_repo = exec(gr, vec!["repo", "get"], false);
+    assert!(no_repo.is_err());
+
+    // Delete created repositories
+    env::set_current_dir("..")?;
+    fs::remove_dir_all(&first_repo)?;
+    fs::remove_dir_all(&second_repo)?;
+    env::set_current_dir(&base_dir)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_bitbucket_repo() {
+    match test_repo() {
+        Ok(()) => (),
+        Err(err) => assert_eq!(err.to_string(), "^^^"),
+    }
+}

--- a/tests/repo-bitbucket.rs
+++ b/tests/repo-bitbucket.rs
@@ -46,21 +46,21 @@ fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
 
 fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     let mut repo_lines = repo.iter();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
     repo_lines.next();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
 
     Ok(())
 }
 
 fn test_forked_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     let mut repo_lines = repo.iter();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
     assert!(repo_lines.next().unwrap().contains("forked from"));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
     repo_lines.next();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
 
     Ok(())
 }

--- a/tests/repo-bitbucket.rs
+++ b/tests/repo-bitbucket.rs
@@ -118,7 +118,13 @@ fn test_repo() -> Result<()> {
     env::set_current_dir("..")?;
     let repo = exec(
         gr,
-        vec!["repo", "fork", &forked_url, &format!("{fork_into}/{second_repo}"), "--clone"],
+        vec![
+            "repo",
+            "fork",
+            &forked_url,
+            &format!("{fork_into}/{second_repo}"),
+            "--clone",
+        ],
         false,
     )?;
     test_forked_repo_result(repo, &second_repo)?;

--- a/tests/repo-bitbucket.rs
+++ b/tests/repo-bitbucket.rs
@@ -54,6 +54,17 @@ fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     Ok(())
 }
 
+fn test_forked_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
+    let mut repo_lines = repo.iter();
+    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains("forked from"));
+    assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
+    repo_lines.next();
+    assert!(repo_lines.next().unwrap().contains(&key));
+
+    Ok(())
+}
+
 fn test_repo() -> Result<()> {
     let key = str_rnd(12).to_ascii_lowercase();
 
@@ -110,12 +121,12 @@ fn test_repo() -> Result<()> {
         vec!["repo", "fork", &forked_url, &format!("{fork_into}/{second_repo}"), "--clone"],
         false,
     )?;
-    test_repo_result(repo, &second_repo)?;
+    test_forked_repo_result(repo, &second_repo)?;
     env::set_current_dir(&second_repo)?;
 
     // Test if the forked repo exists
     let repo = exec(gr, vec!["repo", "get"], false)?;
-    test_repo_result(repo, &second_repo)?;
+    test_forked_repo_result(repo, &second_repo)?;
 
     // Delete the repo, and test if it is actually deleted
     exec(

--- a/tests/repo-bitbucket.rs
+++ b/tests/repo-bitbucket.rs
@@ -45,8 +45,6 @@ fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
 }
 
 fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
-    dbg!(&repo);
-
     let mut repo_lines = repo.iter();
     assert!(repo_lines.next().unwrap().contains(&key));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));

--- a/tests/repo-gitea.rs
+++ b/tests/repo-gitea.rs
@@ -47,21 +47,21 @@ fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
 
 fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     let mut repo_lines = repo.iter();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
     repo_lines.next();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
 
     Ok(())
 }
 
 fn test_forked_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     let mut repo_lines = repo.iter();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
     assert!(repo_lines.next().unwrap().contains("forked from"));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
     repo_lines.next();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
 
     Ok(())
 }

--- a/tests/repo-gitea.rs
+++ b/tests/repo-gitea.rs
@@ -46,9 +46,6 @@ fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
 }
 
 fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
-    dbg!(&key);
-    dbg!(&repo);
-
     let mut repo_lines = repo.iter();
     assert!(repo_lines.next().unwrap().contains(&key));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));

--- a/tests/repo-gitea.rs
+++ b/tests/repo-gitea.rs
@@ -55,6 +55,17 @@ fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     Ok(())
 }
 
+fn test_forked_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
+    let mut repo_lines = repo.iter();
+    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains("forked from"));
+    assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
+    repo_lines.next();
+    assert!(repo_lines.next().unwrap().contains(&key));
+
+    Ok(())
+}
+
 fn test_repo() -> Result<()> {
     let key = str_rnd(12);
 
@@ -115,12 +126,12 @@ fn test_repo() -> Result<()> {
         vec!["repo", "fork", &forked_url, &second_repo, "--clone"],
         false,
     )?;
-    test_repo_result(repo, &second_repo)?;
+    test_forked_repo_result(repo, &second_repo)?;
     env::set_current_dir(&second_repo)?;
 
     // Test if the forked repo exists
     let repo = exec(gr, vec!["repo", "get"], false)?;
-    test_repo_result(repo, &second_repo)?;
+    test_forked_repo_result(repo, &second_repo)?;
 
     // Delete the repo, and test if it is actually deleted
     exec(

--- a/tests/repo-gitea.rs
+++ b/tests/repo-gitea.rs
@@ -1,0 +1,152 @@
+use eyre::{eyre, Result};
+use rand::{distributions::Alphanumeric, Rng};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::{env, fs};
+
+fn str_rnd(count: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(count)
+        .map(char::from)
+        .collect()
+}
+
+fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
+    let command = Command::new(cmd)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(if inherit {
+            Stdio::inherit()
+        } else {
+            Stdio::piped()
+        })
+        .stderr(if inherit {
+            Stdio::inherit()
+        } else {
+            Stdio::piped()
+        })
+        .output()?;
+
+    if command.status.success() {
+        let output = String::from_utf8_lossy(&command.stdout).to_string();
+        Ok(output
+            .lines()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>())
+    } else {
+        Err(eyre!(
+            "{} {:?} {} {}",
+            cmd,
+            args,
+            String::from_utf8_lossy(&command.stdout).to_string(),
+            String::from_utf8_lossy(&command.stderr).to_string()
+        ))
+    }
+}
+
+fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
+    dbg!(&key);
+    dbg!(&repo);
+
+    let mut repo_lines = repo.iter();
+    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
+    repo_lines.next();
+    assert!(repo_lines.next().unwrap().contains(&key));
+
+    Ok(())
+}
+
+fn test_repo() -> Result<()> {
+    let key = str_rnd(12);
+
+    let forked_url = env::var("GR_GITEA_FORKED_REPOSITORY_URL")
+        .unwrap_or("git@codeberg.org:gr-bin-test2/gr-bin-forked.git".to_string());
+
+    let base_dir = env::current_dir()?;
+    let repositories_dir = base_dir.join("tests").join("repositories");
+    let gr_path = base_dir.join("target/debug/gr");
+    let gr = gr_path.to_str().unwrap();
+
+    // Create new repo and clone it
+    let first_repo = format!("{key}-1");
+    env::set_current_dir(repositories_dir)?;
+    let repo = exec(
+        gr,
+        vec![
+            "repo",
+            "new",
+            &first_repo,
+            "--clone",
+            "--host=codeberg.org",
+            "--init",
+            "--default-branch=develop",
+            "--gitignore=Rust",
+            "--license=MIT",
+        ],
+        false,
+    )?;
+    test_repo_result(repo, &first_repo)?;
+    env::set_current_dir(&first_repo)?;
+
+    // Test if the cloned repo is correct
+    let branch = exec("git", vec!["rev-parse", "--abbrev-ref", "HEAD"], false)?;
+    assert_eq!(branch[0], "develop");
+    assert!(Path::new("README.md").exists());
+    assert!(Path::new(".gitignore").exists());
+    assert!(Path::new("LICENSE").exists());
+
+    // Test if the repo exists
+    let repo = exec(gr, vec!["repo", "get"], false)?;
+    test_repo_result(repo, &first_repo)?;
+
+    // Delete the repo, and test if it is actually deleted
+    exec(
+        gr,
+        vec!["repo", "delete", "--yes-delete-permanently"],
+        false,
+    )?;
+    let no_repo = exec(gr, vec!["repo", "get"], false);
+    assert!(no_repo.is_err());
+
+    // Fork repo and clone it
+    let second_repo = format!("{key}-2");
+    env::set_current_dir("..")?;
+    let repo = exec(
+        gr,
+        vec!["repo", "fork", &forked_url, &second_repo, "--clone"],
+        false,
+    )?;
+    test_repo_result(repo, &second_repo)?;
+    env::set_current_dir(&second_repo)?;
+
+    // Test if the forked repo exists
+    let repo = exec(gr, vec!["repo", "get"], false)?;
+    test_repo_result(repo, &second_repo)?;
+
+    // Delete the repo, and test if it is actually deleted
+    exec(
+        gr,
+        vec!["repo", "delete", "--yes-delete-permanently"],
+        false,
+    )?;
+    let no_repo = exec(gr, vec!["repo", "get"], false);
+    assert!(no_repo.is_err());
+
+    // Delete created repositories
+    env::set_current_dir("..")?;
+    fs::remove_dir_all(&first_repo)?;
+    fs::remove_dir_all(&second_repo)?;
+    env::set_current_dir(&base_dir)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_gitea_repo() {
+    match test_repo() {
+        Ok(()) => (),
+        Err(err) => assert_eq!(err.to_string(), "^^^"),
+    }
+}

--- a/tests/repo-github.rs
+++ b/tests/repo-github.rs
@@ -47,21 +47,21 @@ fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
 
 fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     let mut repo_lines = repo.iter();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
     repo_lines.next();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
 
     Ok(())
 }
 
 fn test_forked_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     let mut repo_lines = repo.iter();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
     assert!(repo_lines.next().unwrap().contains("forked from"));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
     repo_lines.next();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
 
     Ok(())
 }

--- a/tests/repo-github.rs
+++ b/tests/repo-github.rs
@@ -55,6 +55,17 @@ fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     Ok(())
 }
 
+fn test_forked_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
+    let mut repo_lines = repo.iter();
+    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains("forked from"));
+    assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
+    repo_lines.next();
+    assert!(repo_lines.next().unwrap().contains(&key));
+
+    Ok(())
+}
+
 fn test_repo() -> Result<()> {
     let key = str_rnd(12);
 
@@ -114,12 +125,12 @@ fn test_repo() -> Result<()> {
         vec!["repo", "fork", &forked_url, &second_repo, "--clone"],
         false,
     )?;
-    test_repo_result(repo, &second_repo)?;
+    test_forked_repo_result(repo, &second_repo)?;
     env::set_current_dir(&second_repo)?;
 
     // Test if the forked repo exists
     let repo = exec(gr, vec!["repo", "get"], false)?;
-    test_repo_result(repo, &second_repo)?;
+    test_forked_repo_result(repo, &second_repo)?;
 
     // Delete the repo, and test if it is actually deleted
     exec(

--- a/tests/repo-github.rs
+++ b/tests/repo-github.rs
@@ -46,8 +46,6 @@ fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
 }
 
 fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
-	dbg!(&repo);
-	
     let mut repo_lines = repo.iter();
     assert!(repo_lines.next().unwrap().contains(&key));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));

--- a/tests/repo-github.rs
+++ b/tests/repo-github.rs
@@ -1,0 +1,150 @@
+use eyre::{eyre, Result};
+use rand::{distributions::Alphanumeric, Rng};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::{env, fs};
+
+fn str_rnd(count: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(count)
+        .map(char::from)
+        .collect()
+}
+
+fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
+    let command = Command::new(cmd)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(if inherit {
+            Stdio::inherit()
+        } else {
+            Stdio::piped()
+        })
+        .stderr(if inherit {
+            Stdio::inherit()
+        } else {
+            Stdio::piped()
+        })
+        .output()?;
+
+    if command.status.success() {
+        let output = String::from_utf8_lossy(&command.stdout).to_string();
+        Ok(output
+            .lines()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>())
+    } else {
+        Err(eyre!(
+            "{} {:?} {} {}",
+            cmd,
+            args,
+            String::from_utf8_lossy(&command.stdout).to_string(),
+            String::from_utf8_lossy(&command.stderr).to_string()
+        ))
+    }
+}
+
+fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
+	dbg!(&repo);
+	
+    let mut repo_lines = repo.iter();
+    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
+    repo_lines.next();
+    assert!(repo_lines.next().unwrap().contains(&key));
+
+    Ok(())
+}
+
+fn test_repo() -> Result<()> {
+    let key = str_rnd(12);
+
+    let forked_url = env::var("GR_GITHUB_FORKED_REPOSITORY_URL")
+        .unwrap_or("git@github.com:gr-bin-test2/gr-bin-forked.git".to_string());
+
+    let base_dir = env::current_dir()?;
+    let repositories_dir = base_dir.join("tests").join("repositories");
+    let gr_path = base_dir.join("target/debug/gr");
+    let gr = gr_path.to_str().unwrap();
+
+    // Create new repo and clone it
+    let first_repo = format!("{key}-1");
+    env::set_current_dir(repositories_dir)?;
+    let repo = exec(
+        gr,
+        vec![
+            "repo",
+            "new",
+            &first_repo,
+            "--clone",
+            "--host=github.com",
+            "--init",
+            "--gitignore=Rust",
+            "--license=MIT",
+        ],
+        false,
+    )?;
+    test_repo_result(repo, &first_repo)?;
+    env::set_current_dir(&first_repo)?;
+
+    // Test if the cloned repo is correct
+    let branch = exec("git", vec!["rev-parse", "--abbrev-ref", "HEAD"], false)?;
+    assert_eq!(branch[0], "main");
+    assert!(Path::new("README.md").exists());
+    assert!(Path::new(".gitignore").exists());
+    assert!(Path::new("LICENSE").exists());
+
+    // Test if the repo exists
+    let repo = exec(gr, vec!["repo", "get"], false)?;
+    test_repo_result(repo, &first_repo)?;
+
+    // Delete the repo, and test if it is actually deleted
+    exec(
+        gr,
+        vec!["repo", "delete", "--yes-delete-permanently"],
+        false,
+    )?;
+    let no_repo = exec(gr, vec!["repo", "get"], false);
+    assert!(no_repo.is_err());
+
+    // Fork repo and clone it
+    let second_repo = format!("{key}-2");
+    env::set_current_dir("..")?;
+    let repo = exec(
+        gr,
+        vec!["repo", "fork", &forked_url, &second_repo, "--clone"],
+        false,
+    )?;
+    test_repo_result(repo, &second_repo)?;
+    env::set_current_dir(&second_repo)?;
+
+    // Test if the forked repo exists
+    let repo = exec(gr, vec!["repo", "get"], false)?;
+    test_repo_result(repo, &second_repo)?;
+
+    // Delete the repo, and test if it is actually deleted
+    exec(
+        gr,
+        vec!["repo", "delete", "--yes-delete-permanently"],
+        false,
+    )?;
+    let no_repo = exec(gr, vec!["repo", "get"], false);
+    assert!(no_repo.is_err());
+
+    // Delete created repositories
+    env::set_current_dir("..")?;
+    fs::remove_dir_all(&first_repo)?;
+    fs::remove_dir_all(&second_repo)?;
+    env::set_current_dir(&base_dir)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_github_repo() {
+    match test_repo() {
+        Ok(()) => (),
+        Err(err) => assert_eq!(err.to_string(), "^^^"),
+    }
+}

--- a/tests/repo-gitlab.rs
+++ b/tests/repo-gitlab.rs
@@ -47,21 +47,21 @@ fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
 
 fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     let mut repo_lines = repo.iter();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
     repo_lines.next();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
 
     Ok(())
 }
 
 fn test_forked_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     let mut repo_lines = repo.iter();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
     assert!(repo_lines.next().unwrap().contains("forked from"));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
     repo_lines.next();
-    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains(key));
 
     Ok(())
 }

--- a/tests/repo-gitlab.rs
+++ b/tests/repo-gitlab.rs
@@ -46,9 +46,6 @@ fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
 }
 
 fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
-    dbg!(&key);
-    dbg!(&repo);
-
     let mut repo_lines = repo.iter();
     assert!(repo_lines.next().unwrap().contains(&key));
     assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));

--- a/tests/repo-gitlab.rs
+++ b/tests/repo-gitlab.rs
@@ -1,0 +1,148 @@
+use eyre::{eyre, Result};
+use rand::{distributions::Alphanumeric, Rng};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::{env, fs};
+
+fn str_rnd(count: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(count)
+        .map(char::from)
+        .collect()
+}
+
+fn exec(cmd: &str, args: Vec<&str>, inherit: bool) -> Result<Vec<String>> {
+    let command = Command::new(cmd)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(if inherit {
+            Stdio::inherit()
+        } else {
+            Stdio::piped()
+        })
+        .stderr(if inherit {
+            Stdio::inherit()
+        } else {
+            Stdio::piped()
+        })
+        .output()?;
+
+    if command.status.success() {
+        let output = String::from_utf8_lossy(&command.stdout).to_string();
+        Ok(output
+            .lines()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>())
+    } else {
+        Err(eyre!(
+            "{} {:?} {} {}",
+            cmd,
+            args,
+            String::from_utf8_lossy(&command.stdout).to_string(),
+            String::from_utf8_lossy(&command.stderr).to_string()
+        ))
+    }
+}
+
+fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
+    dbg!(&key);
+    dbg!(&repo);
+
+    let mut repo_lines = repo.iter();
+    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
+    repo_lines.next();
+    assert!(repo_lines.next().unwrap().contains(&key));
+
+    Ok(())
+}
+
+fn test_repo() -> Result<()> {
+    let key = str_rnd(12);
+
+    let forked_url = env::var("GR_GITLAB_FORKED_REPOSITORY_URL")
+        .unwrap_or("git@gitlab.com:grbin-test2/gr-bin-forked.git".to_string());
+
+    let base_dir = env::current_dir()?;
+    let repositories_dir = base_dir.join("tests").join("repositories");
+    let gr_path = base_dir.join("target/debug/gr");
+    let gr = gr_path.to_str().unwrap();
+
+    // Create new repo and clone it
+    let first_repo = format!("{key}-1");
+    env::set_current_dir(repositories_dir)?;
+    let repo = exec(
+        gr,
+        vec![
+            "repo",
+            "new",
+            &first_repo,
+            "--clone",
+            "--host=gitlab.com",
+            "--init",
+            "--default-branch=develop",
+        ],
+        false,
+    )?;
+    test_repo_result(repo, &first_repo)?;
+    env::set_current_dir(&first_repo)?;
+
+    // Test if the cloned repo is correct
+    let branch = exec("git", vec!["rev-parse", "--abbrev-ref", "HEAD"], false)?;
+    assert_eq!(branch[0], "develop");
+    assert!(Path::new("README.md").exists());
+
+    // Test if the repo exists
+    let repo = exec(gr, vec!["repo", "get"], false)?;
+    test_repo_result(repo, &first_repo)?;
+
+    // Delete the repo, and test if it is actually deleted
+    exec(
+        gr,
+        vec!["repo", "delete", "--yes-delete-permanently"],
+        false,
+    )?;
+    let no_repo = exec(gr, vec!["repo", "get"], false);
+    assert!(no_repo.is_err());
+
+    // Fork repo and clone it
+    let second_repo = format!("{key}-2");
+    env::set_current_dir("..")?;
+    let repo = exec(
+        gr,
+        vec!["repo", "fork", &forked_url, &second_repo, "--clone"],
+        false,
+    )?;
+    test_repo_result(repo, &second_repo)?;
+    env::set_current_dir(&second_repo)?;
+
+    // Test if the forked repo exists
+    let repo = exec(gr, vec!["repo", "get"], false)?;
+    test_repo_result(repo, &second_repo)?;
+
+    // Delete the repo, and test if it is actually deleted
+    exec(
+        gr,
+        vec!["repo", "delete", "--yes-delete-permanently"],
+        false,
+    )?;
+    let no_repo = exec(gr, vec!["repo", "get"], false);
+    assert!(no_repo.is_err());
+
+    // Delete created repositories
+    env::set_current_dir("..")?;
+    fs::remove_dir_all(&first_repo)?;
+    fs::remove_dir_all(&second_repo)?;
+    env::set_current_dir(&base_dir)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_gitlab_repo() {
+    match test_repo() {
+        Ok(()) => (),
+        Err(err) => assert_eq!(err.to_string(), "^^^"),
+    }
+}

--- a/tests/repo-gitlab.rs
+++ b/tests/repo-gitlab.rs
@@ -55,6 +55,17 @@ fn test_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
     Ok(())
 }
 
+fn test_forked_repo_result(repo: Vec<String>, key: &str) -> Result<()> {
+    let mut repo_lines = repo.iter();
+    assert!(repo_lines.next().unwrap().contains(&key));
+    assert!(repo_lines.next().unwrap().contains("forked from"));
+    assert!(repo_lines.next().unwrap().contains("0 stars, 0 forks"));
+    repo_lines.next();
+    assert!(repo_lines.next().unwrap().contains(&key));
+
+    Ok(())
+}
+
 fn test_repo() -> Result<()> {
     let key = str_rnd(12);
 
@@ -111,12 +122,12 @@ fn test_repo() -> Result<()> {
         vec!["repo", "fork", &forked_url, &second_repo, "--clone"],
         false,
     )?;
-    test_repo_result(repo, &second_repo)?;
+    test_forked_repo_result(repo, &second_repo)?;
     env::set_current_dir(&second_repo)?;
 
     // Test if the forked repo exists
     let repo = exec(gr, vec!["repo", "get"], false)?;
-    test_repo_result(repo, &second_repo)?;
+    test_forked_repo_result(repo, &second_repo)?;
 
     // Delete the repo, and test if it is actually deleted
     exec(


### PR DESCRIPTION
- Refactor forking to store in the configuration
- Add cross repo pull requests
- Fix clippy errors
- Add extra description for forked repositories
- Update the CHANGELOG
- Revert "Try to parallelize testing with nextest"
- Fix install version number
- Try to parallelize testing with nextest
- Move back all tests
- Add minimal waiting time to allow server to finish forking
- Continue with testing
- Add tracing information to debug github clone
- Remove debug messages from tests
- Fix clippy errors
- Add end to end tests for repository
- Add hidden repo delete command
- Fix Bitbucket user different types
- Add more features to repository create flow
- Fix bugs with Bitbucket and GitLab
- Add clone option to forking
- Add open option to repo creation
- Change output format
- Add fork repository operation
- Add initial fork implementations to servers
- Change default visibility to private
- Refactor cloning and pushing logic
- Add automatic cloning
- Add clone URLs to repository
- Add repository creation
- Add Gitea integration to repository get
- Merge branch 'master' into feature/repository-command
- Add repository object for every server
- Scaffold repository commands
