### PR TITLE
Add GitHub Enterprise integration and hostname-based assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 -   Add GitHub Enterprise integration
+-   Add assumptions to VCS type if the hostname matches "github", "gitlab" or "gitea"
 
 ## [0.2.0] - 2023-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+-   Add GitHub Enterprise integration
+
 ## [0.2.0] - 2023-05-29
 
 -   Add Gitea integration

--- a/src/utils/tracing.rs
+++ b/src/utils/tracing.rs
@@ -24,7 +24,7 @@ pub fn init_tracing(verbosity: u8, output: OutputType) -> Result<()> {
             1 => LevelFilter::INFO,
             2 => LevelFilter::DEBUG,
             3 => LevelFilter::TRACE,
-            _ => LevelFilter::ERROR,
+            _ => LevelFilter::WARN,
         });
 
     // Select output to JSON, or leave it regular

--- a/src/vcs/common.rs
+++ b/src/vcs/common.rs
@@ -2,6 +2,7 @@ use eyre::{eyre, Result};
 use open::that as open_in_browser;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
+use tracing::warn;
 
 use crate::formatters::formatter::{Formatter, FormatterType};
 use crate::vcs::{bitbucket::Bitbucket, gitea::Gitea, github::GitHub, gitlab::GitLab};
@@ -194,9 +195,29 @@ pub fn init_vcs(
             "github.com" => Ok(Box::new(GitHub::init(hostname, repo, settings))),
             "bitbucket.org" => Ok(Box::new(Bitbucket::init(hostname, repo, settings))),
             "gitlab.com" => Ok(Box::new(GitLab::init(hostname, repo, settings))),
-            _ => Err(eyre!(
-                "Server {hostname} type cannot be detected, add --type at login."
-            )),
+            _ => {
+                // Take some guesses what the host might be
+                if hostname.contains("github") {
+                    warn!("Assuming the host to be GitHub Enterprise (if it is incorrect, add --type at login).");
+                    Ok(Box::new(GitHub::init(hostname, repo, settings)))
+                } else if hostname.contains("gitlab") {
+                    warn!(
+                        "Assuming the host to be GitLab (if it is incorrect, add --type at login)."
+                    );
+                    Ok(Box::new(GitLab::init(hostname, repo, settings)))
+                } else if hostname.contains("gitea") {
+                    warn!(
+                        "Assuming the host to be Gitea (if it is incorrect, add --type at login)."
+                    );
+                    Ok(Box::new(Gitea::init(hostname, repo, settings)))
+                }
+                // Probably there should more detections down the line
+                else {
+                    Err(eyre!(
+                        "Server {hostname} type cannot be detected, add --type at login."
+                    ))
+                }
+            }
         }
     }
 }

--- a/src/vcs/github.rs
+++ b/src/vcs/github.rs
@@ -282,6 +282,7 @@ pub struct GitHub {
     settings: VersionControlSettings,
     client: Agent,
     repo: String,
+    hostname: String,
 }
 
 impl GitHub {
@@ -296,7 +297,12 @@ impl GitHub {
         url: &str,
         body: Option<U>,
     ) -> Result<T> {
-        let url = format!("https://api.github.com{}", url);
+        // Base URL is api.github.com or /api/v3, see https://stackoverflow.com/a/50612869
+        let hostname = match self.hostname.as_str() {
+            "github.com" => "api.github.com".to_string(),
+            hostname => format!("{hostname}/api/v3"),
+        };
+        let url = format!("https://{}{}", hostname, url);
 
         info!("Calling with {method} on {url}.");
 
@@ -359,19 +365,24 @@ impl GitHub {
 
 impl VersionControl for GitHub {
     #[instrument(skip_all)]
-    fn init(_: String, repo: String, settings: VersionControlSettings) -> Self {
+    fn init(hostname: String, repo: String, settings: VersionControlSettings) -> Self {
         let client = AgentBuilder::new()
             .tls_connector(Arc::new(TlsConnector::new().unwrap()))
             .build();
+
         GitHub {
             settings,
             client,
             repo,
+            hostname,
         }
     }
     #[instrument(skip_all)]
     fn login_url(&self) -> String {
-        "https://github.com/settings/tokens/new?description=gr&scopes=repo,project".to_string()
+        format!(
+            "https://{}/settings/tokens/new?description=gr&scopes=repo,project",
+            self.hostname
+        )
     }
 
     #[instrument(skip_all)]


### PR DESCRIPTION
- Update changelog
- Add vcs type assumptions if the hostname matches a string
- Update changelog
- Add option for GitHub Enterprise
